### PR TITLE
Bugfix: Support drag handles with children

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -75,7 +75,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				let {useDragHandle} = this.props;
 				let {index, collection} = node.sortableInfo;
 
-				if (useDragHandle && !e.target.sortableHandle) return;
+				if (useDragHandle && !closest(e.target, (el) => el.sortableHandle != null)) return;
 
 				this.manager.active = {index, collection};
 				this.pressTimer = setTimeout(() => this.handlePress(e), this.props.pressDelay);


### PR DESCRIPTION
This PR walks parents to find the actual drag handle instance. Without this, sorting won't work if a handle has any children (`e.target.sortableHandle` isn't always the actual handle). To reproduce, use this as a drag handle:

```js
render() { return <span><span>::</span></span>; }
```

Great library by the way!