### PR TITLE
Bugfix: Fixed index state not being updated

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -1,5 +1,6 @@
 import find from 'lodash/find';
 import sortBy from 'lodash/sortBy';
+import {arrayMove} from './utils';
 
 export default class Manager {
 	refs = {};
@@ -13,6 +14,14 @@ export default class Manager {
 	}
 	getOrderedRefs(collection = this.active.collection) {
 		return sortBy(this.refs[collection], 'index');
+	}
+	move(collection, oldIndex, newIndex) {
+		const nodes = this.refs[collection];
+		arrayMove(nodes, oldIndex, newIndex);
+		for (let i = 0, len = nodes.length; i < len; i++) {
+			nodes[i].index = i;
+			nodes[i].node.sortableInfo.index = i;
+		}
 	}
 	remove(collection, ref) {
 		let index = this.getIndex(collection, ref);

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -156,6 +156,8 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 		handleSortEnd = (e) => {
 			let {hideSortableGhost, onSortEnd} = this.props;
 			let {collection} = this.manager.active;
+			const oldIndex = this.index;
+			const newIndex = this.newIndex;
 
 			// Remove the event listeners if the node is still in the DOM
 			if (this.listenerNode) {
@@ -170,11 +172,16 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				this.node.style.visibility = '';
 			}
 
+			// Re-sort nodes to account for new order
+			this.manager.move(collection, oldIndex, newIndex);
+
 			let nodes = this.manager.refs[collection];
 			for (let i = 0, len = nodes.length; i < len; i++) {
 				let node = nodes[i];
-				let {node: el} = node;
-				node.edgeOffset = null; // Clear the cached offsetTop / offsetLeft value
+				let el = node.node;
+
+				// Clear the cached offsetTop / offsetLeft value
+				node.edgeOffset = null;
 
 				// Remove the transforms / transitions
 				el.style[`${vendorPrefix}Transform`] = '';
@@ -183,8 +190,8 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 
 			if (typeof onSortEnd == 'function') {
 				onSortEnd({
-					oldIndex: this.index,
-					newIndex: this.newIndex,
+					oldIndex,
+					newIndex,
 					collection: collection
 				}, e);
 			}


### PR DESCRIPTION
It seems that currently an item's index updates only *if* the item unmounts/remounts after the dragging ends ([source](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableElement/index.js#L21-L37))? I was getting wonky behavior after my first drag/drop because an element's `index` wasn't being updated at the end of dragging (even though I reordered the data outside of the control like in the examples).

Take this PR with a grain of salt. I couldn't totally wrap my head around where this library keeps it's "source of truth". It seems to be in a few places – I tried to cover the bases, but could be approaching this wrong.

Any ideas?