### PR TITLE
Fix helperClass

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -129,7 +129,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				}
 
 				if (helperClass) {
-					this.helper.classList.add(helperClass.split(' '));
+					this.helper.classList.add(...(helperClass.split(' ')));
 				}
 
 				this.listenerNode = (e.touches) ? node : this.contentWindow;


### PR DESCRIPTION
when adding multiple classes with `classList.add` they must be like this `'foo', 'bar'` currently they are applied like this `'foo, bar'`. So this will fix this issue and will allow to add multiple classes. 

keep in mind that the space after the backtick is required.