### PR TITLE
Bugfix: Add support handling `margin`s on scrollable items. (fixes #26)

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import Manager from '../Manager';
-import {closest, events, vendorPrefix, limit} from '../utils';
+import {closest, events, vendorPrefix, limit, getElementMargin} from '../utils';
 import invariant from 'invariant';
 
 // Export Higher Order Sortable Container Component
@@ -100,13 +100,19 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				let {axis, onSortStart, helperClass, hideSortableGhost, useWindowAsScrollContainer} = this.props;
 				let {node, collection} = active;
 				let index = node.sortableInfo.index;
+				const margin = getElementMargin(node);
 
 				let containerBoundingRect = this.container.getBoundingClientRect();
 
 				this.node = node;
+				this.margin = margin;
 				this.width = node.offsetWidth;
 				this.height = node.offsetHeight;
 				this.dimension = (axis == 'x') ? this.width : this.height;
+				this.marginOffset = {
+					x: this.margin.left + this.margin.right,
+					y: Math.max(this.margin.top, this.margin.bottom)
+				};
 				this.boundingClientRect = node.getBoundingClientRect();
 				this.index = index;
 				this.newIndex = index;
@@ -118,8 +124,8 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 
 				this.helper = this.document.body.appendChild(node.cloneNode(true));
 				this.helper.style.position = 'fixed';
-				this.helper.style.top = `${this.boundingClientRect.top}px`;
-				this.helper.style.left = `${this.boundingClientRect.left}px`;
+				this.helper.style.top = `${this.boundingClientRect.top - margin.top}px`;
+				this.helper.style.left = `${this.boundingClientRect.left - margin.left}px`;
 				this.helper.style.width = `${this.width}px`;
 
 				if (hideSortableGhost) {
@@ -339,12 +345,13 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				if (transitionDuration) {
 					node.style[`${vendorPrefix}TransitionDuration`] = `${transitionDuration}ms`;
 				}
+
 				if (index > this.index && (sortingOffset + offset >= edgeOffset)) {
-					translate = -this.dimension;
+					translate = -(this.dimension + this.marginOffset[axis]);
 					this.newIndex = index;
 				}
 				else if (index < this.index && (sortingOffset <= edgeOffset + offset)) {
-					translate = this.dimension;
+					translate = this.dimension + this.marginOffset[axis];
 
 					if (this.newIndex == null) {
 						this.newIndex = index;

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,3 +47,21 @@ export function limit(min, max, value) {
     }
     return value;
 }
+
+function getCSSPixelValue(stringValue) {
+    if (stringValue.substr(-2) === 'px') {
+        return parseFloat(stringValue);
+    }
+    return 0;
+}
+
+export function getElementMargin(element) {
+    const style = window.getComputedStyle(element);
+
+    return {
+        top   : getCSSPixelValue(style.marginTop),
+        right : getCSSPixelValue(style.marginRight),
+        bottom: getCSSPixelValue(style.marginBottom),
+        left  : getCSSPixelValue(style.marginLeft),
+    };
+}


### PR DESCRIPTION
Only support's [margin collapsing](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing) if all items have the same margins.
[How to uncollapse margin for adjacent siblings](http://stackoverflow.com/questions/1828804/how-do-i-uncollapse-a-margin#answer-1828940)
[How to disable margin collapsing](http://stackoverflow.com/questions/19718634/how-to-disable-margin-collapsing#answer-19719427)
