### PR TITLE
add ref to manager when disabled prop goes from true to false

### DIFF
--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -28,7 +28,7 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
             addOrRemove(collection, this.ref)
         }
         componentDidMount() {
-            this.addOrRemoveRef(this.props.disabled)
+            this.addOrRemoveRef(!this.props.disabled)
         }
         componentWillReceiveProps(nextProps) {
             const {index} = this.props;

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -20,15 +20,15 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
         };
         addRef() {
             let node = this.node = findDOMNode(this);
-
+            let {collection, index} = this.props;
+            
             node.sortableInfo = {index, collection};
 
             this.ref = {node};
             this.context.manager.add(collection, this.ref);
         }
         componentDidMount() {
-            let {collection, disabled, index} = this.props;
-
+            let {disabled} = this.props;
             if (!disabled) {
                 this.addRef()
             }

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -18,20 +18,17 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
         static defaultProps = {
             collection: 0
         };
-        addRef() {
+        addOrRemoveRef(shouldAdd) {
             let node = this.node = findDOMNode(this);
             let {collection, index} = this.props;
-            
+            let {manager} = this.context;
             node.sortableInfo = {index, collection};
-
             this.ref = {node};
-            this.context.manager.add(collection, this.ref);
+            let addOrRemove = (shouldAdd) ? manager.add : manager.remove;
+            addOrRemove(collection, this.ref)
         }
         componentDidMount() {
-            let {disabled} = this.props;
-            if (!disabled) {
-                this.addRef()
-            }
+            this.addOrRemoveRef(this.props.disabled)
         }
         componentWillReceiveProps(nextProps) {
             const {index} = this.props;
@@ -39,8 +36,8 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
                 this.node.sortableInfo.index = nextProps.index;
             }
 
-            if (this.props.disabled && !nextProps.disabled) {
-                this.addRef();
+            if (this.props.disabled !== nextProps.disabled) {
+                this.addOrRemoveRef(!nextProps.disabled)
             }
         }
         componentWillUnmount() {

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -18,22 +18,29 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
         static defaultProps = {
             collection: 0
         };
+        addRef() {
+            let node = this.node = findDOMNode(this);
+
+            node.sortableInfo = {index, collection};
+
+            this.ref = {node};
+            this.context.manager.add(collection, this.ref);
+        }
         componentDidMount() {
             let {collection, disabled, index} = this.props;
 
             if (!disabled) {
-                let node = this.node = findDOMNode(this);
-
-                node.sortableInfo = {index, collection};
-
-                this.ref = {node};
-                this.context.manager.add(collection, this.ref);
+                this.addRef()
             }
         }
         componentWillReceiveProps(nextProps) {
             const {index} = this.props;
             if (index !== nextProps.index && this.node) {
                 this.node.sortableInfo.index = nextProps.index;
+            }
+
+            if (this.props.disabled && !nextProps.disabled) {
+                this.addRef();
             }
         }
         componentWillUnmount() {


### PR DESCRIPTION
This fixes an issue for when a `SortableElement` goes from a disabled to a non-disabled state.