### PR TITLE
support changable collection

### DIFF
--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -41,6 +41,10 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
                     this.setDraggable(collection, index);
                 }
             }
+            else if (this.props.collection !== nextProps.collection) {
+                this.removeDraggable(this.props.collection);
+                this.setDraggable(nextProps.collection, nextProps.index);
+            }
         }
         componentWillUnmount() {
             let {collection, disabled} = this.props;


### PR DESCRIPTION
my collection name changes ( I keep the path to the parent in the collection name, eg 'grandparent:0:parent:5:children' )  and the parents themselves are sortable, as such their indexes can change.
I didn't want to bind a new closure for each `onSortEnd` because I have so many items.
Anyhow, one PR