### PR TITLE
Fix timing issue in Chrome

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -111,7 +111,11 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				this.manager.active = {index, collection};
 
 				if (!distance) {
-					this.pressTimer = setTimeout(() => this.handlePress(e), this.props.pressDelay);
+					if (this.props.pressDelay === 0) {
+						this.handlePress(e);
+					} else {
+						this.pressTimer = setTimeout(() => this.handlePress(e), this.props.pressDelay);
+					}
 				}
 			}
 		};


### PR DESCRIPTION
This change fixes a hard-to-debug and reproduce issue in Chrome. In one window, I can't sort anything at all, either in my application or even on the GitHub pages site. In another Incognito window in the same version of Chrome, I can sort just fine. I think it is a timing issue related to the way `setTimeout` and the `setState` inside `handlePress` interact with each other. I tried eliminating the `setTimeout` when `pressDelay === 0` and the (alleged) timing issue went away.
