### PR TITLE
add touch cancel support for utils

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ export function arrayMove (arr, previousIndex, newIndex) {
 export const events = {
 	start: ['touchstart', 'mousedown'],
 	move: ['touchmove', 'mousemove'],
-	end: ['touchend', 'mouseup']
+	end: ['touchend', 'touchcancel', 'mouseup']
 };
 
 export const vendorPrefix = (function () {


### PR DESCRIPTION
treat touchCancel event like touchEnd to un-mount cloned element from DOM. This should resolve #72 