### PR TITLE
Move cancel to the end of event queue

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -138,7 +138,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 
 				if (!distance) {
 					clearTimeout(this.cancelTimer);
-					this.cancelTimer = setTimeout(this.cancel, 0);
+					this.cancelTimer = setTimeout(() => this.cancel(), 0);
 				} else if (delta >= distance) {
 					this.handlePress(e);
 				}

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -138,7 +138,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 
 				if (!distance) {
 					clearTimeout(this.cancelTimer);
-					this.cancelTimer = setTimeout(() => this.cancel(), 0);
+					this.cancelTimer = setTimeout(this.cancel, 0);
 				} else if (delta >= distance) {
 					this.handlePress(e);
 				}

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -137,7 +137,8 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				const delta = Math.abs(this._delta.x) + Math.abs(this._delta.y);
 
 				if (!distance) {
-					this.cancel();
+					clearTimeout(this.cancelTimer);
+					this.cancelTimer = setTimeout(this.cancel, 0);
 				} else if (delta >= distance) {
 					this.handlePress(e);
 				}


### PR DESCRIPTION
Bottom line up front: Awesome plugin! Keep up the good work. — I’ve looked into a lot of similar components, and this is, by far the most stable, and the most easy to integrate component that I’ve seen so far. — Kudos for that.

**Summary**

This is for people with really sensitive touch devices (like trackpads configured to be really fast; or especially for designers who have gotten used to work fast and with precision.

**What was Happening**

(hard to describe verbally but I’ll try)

* The user starts moving her finger from outside the sortable list towards a sortable container.
* (while not stopping the finger movement on the trackpad) the user lightly touches the trackpad (in trackpad terms: this is a regular touch, not a force touch)
* (still not stopping the finger movement) the user continues to move her finger while keeping the finger lightly touched; hence triggering a touchmove event.

**User’s Experience**

The user has `_touched` the sortable container, but without having time to register a delta a cancel event is fired in the move handler because pressTimer runs the handlePress in a timer. This will cancel the drag but since the user assumes that she’s still dragging, she’ll continue to drag hopelessly expecting the container to move, with no luck.

She will trying to drag the container; but the container will not moving at all.
(because the movement is cancelled before even being able to start; though the finger is still moving on the tracpad and the finger is still pressing against the trackpad)

Since the expected behavior is to see the container drag; container not moving cause a mild annoyance.

**How does this commit solve the issue?**

By setting an immediate timer, we move the cancel event to the tail of the timer queue, and ensure that it is fired after the pressTimer.

That should not impact a typical use case, and enhance the edge case described in this commit.

**Other Options**

If this timer fix does not work for some reason; a second option might be to track the state of the pressTimer; and not fire `cancel` if the press timer has been set but no delta registered yet — though I feel like that will make things even more complicated.