### PR TITLE
The proper way to clear interval

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -480,7 +480,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 			}
 
 			if (this.autoscrollInterval) {
-				clearTimeout(this.autoscrollInterval);
+				clearInterval(this.autoscrollInterval);
 				this.autoscrollInterval = null;
 				this.isAutoScrolling = false;
 			}


### PR DESCRIPTION
Just found a place where used `clearTimeout` instead of `clearInterval` which could cause some side-effects.