### PR TITLE
clauderic/react-sortable-hoc#98 do not pass private props to wrapped …

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -43,7 +43,11 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 				}
 			},
 			lockToContainerEdges: false,
-			lockOffset: '50%'
+			lockOffset: '50%',
+			getHelperDimensions: ({node}) => ({		
+ -				width: node.offsetWidth,		
+ -				height: node.offsetHeight		
+ -			})
 		};
 
 		static propTypes = {
@@ -67,7 +71,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 				PropTypes.string,
 				PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
 			]),
-			getContainer: PropTypes.func
+			getContainer: PropTypes.func,
+			getHelperDimensions: PropTypes.func
 		};
 
 		static childContextTypes = {
@@ -163,17 +168,18 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 			const active = this.manager.getActive();
 
 			if (active) {
-				const {axis, onSortStart, helperClass, hideSortableGhost, useWindowAsScrollContainer} = this.props;
+				const {axis, getHelperDimensions, helperClass, hideSortableGhost, onSortStart, useWindowAsScrollContainer} = this.props;
 				let {node, collection} = active;
 				const {index} = node.sortableInfo;
 				const margin = getElementMargin(node);
 
 				const containerBoundingRect = this.container.getBoundingClientRect();
+				const dimensions = getHelperDimensions({index, node, collection});
 
 				this.node = node;
 				this.margin = margin;
-				this.width = node.offsetWidth;
-				this.height = node.offsetHeight;
+				this.width = dimensions.width;	
+ -				this.height = dimensions.height;
 				this.marginOffset = {
 					x: this.margin.left + this.margin.right,
 					y: Math.max(this.margin.top, this.margin.bottom)

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -179,7 +179,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 				this.node = node;
 				this.margin = margin;
 				this.width = dimensions.width;	
- 				this.height = dimensions.height;
+				this.height = dimensions.height;
 				this.marginOffset = {
 					x: this.margin.left + this.margin.right,
 					y: Math.max(this.margin.top, this.margin.bottom)

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,11 +1,13 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import Manager from '../Manager';
-import {closest, events, vendorPrefix, limit, getElementMargin} from '../utils';
+import { omit } from 'lodash'
 import invariant from 'invariant';
 
+import Manager from '../Manager';
+import {closest, events, vendorPrefix, limit, getElementMargin, provideDisplayName} from '../utils';
+
 // Export Higher Order Sortable Container Component
-export default function SortableContainer(WrappedComponent, config = {withRef: false}) {
+export default function sortableContainer(WrappedComponent, config = {withRef: false}) {
 	return class extends Component {
 		constructor(props) {
 			super(props);
@@ -24,9 +26,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 			this.state = {};
 		}
 
-		static displayName = (WrappedComponent.displayName) ? `SortableList(${WrappedComponent.displayName})` : 'SortableList';
-
-		static WrappedComponent = WrappedComponent;
+		static displayName = provideDisplayName('sortableList', WrappedComponent);
 
 		static defaultProps = {
 			axis: 'y',
@@ -43,11 +43,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				}
 			},
 			lockToContainerEdges: false,
-			lockOffset: '50%',
-			getHelperDimensions: ({node}) => ({
-				width: node.offsetWidth,
-				height: node.offsetHeight
-			})
+			lockOffset: '50%'
 		};
 
 		static propTypes = {
@@ -71,8 +67,7 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				PropTypes.string,
 				PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
 			]),
-			getContainer: PropTypes.func,
-			getHelperDimensions: PropTypes.func
+			getContainer: PropTypes.func
 		};
 
 		static childContextTypes = {
@@ -168,22 +163,17 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 			const active = this.manager.getActive();
 
 			if (active) {
-				const {axis, onSortStart, helperClass, hideSortableGhost, useWindowAsScrollContainer, getHelperDimensions} = this.props;
+				const {axis, onSortStart, helperClass, hideSortableGhost, useWindowAsScrollContainer} = this.props;
 				let {node, collection} = active;
 				const {index} = node.sortableInfo;
 				const margin = getElementMargin(node);
 
 				const containerBoundingRect = this.container.getBoundingClientRect();
-				const dimensions = getHelperDimensions({index, node, collection})
 
 				this.node = node;
-				this.width = dimensions.width
-				this.height = dimensions.height
 				this.margin = margin;
 				this.width = node.offsetWidth;
 				this.height = node.offsetHeight;
-				this.halfWidth = this.width / 2;
-				this.halfHeight = this.height / 2;
 				this.marginOffset = {
 					x: this.margin.left + this.margin.right,
 					y: Math.max(this.margin.top, this.margin.bottom)
@@ -219,12 +209,12 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				this.minTranslate = {};
 				this.maxTranslate = {};
 				if (this.axis.x) {
-					this.minTranslate.x = ((useWindowAsScrollContainer) ? 0 : containerBoundingRect.left) - this.boundingClientRect.left - this.halfWidth;
-					this.maxTranslate.x = ((useWindowAsScrollContainer) ? this.contentWindow.innerWidth : containerBoundingRect.left + containerBoundingRect.width) - this.boundingClientRect.left - this.halfWidth;
+					this.minTranslate.x = ((useWindowAsScrollContainer) ? 0 : containerBoundingRect.left) - this.boundingClientRect.left - (this.width / 2);
+					this.maxTranslate.x = ((useWindowAsScrollContainer) ? this.contentWindow.innerWidth : containerBoundingRect.left + containerBoundingRect.width) - this.boundingClientRect.left - (this.width / 2);
 				}
 				if (this.axis.y) {
-					this.minTranslate.y = ((useWindowAsScrollContainer) ? 0 : containerBoundingRect.top) - this.boundingClientRect.top - this.halfHeight;
-					this.maxTranslate.y = ((useWindowAsScrollContainer) ? this.contentWindow.innerHeight : containerBoundingRect.top + containerBoundingRect.height) - this.boundingClientRect.top - this.halfHeight;
+					this.minTranslate.y = ((useWindowAsScrollContainer) ? 0 : containerBoundingRect.top) - this.boundingClientRect.top - (this.height / 2);
+					this.maxTranslate.y = ((useWindowAsScrollContainer) ? this.contentWindow.innerHeight : containerBoundingRect.top + containerBoundingRect.height) - this.boundingClientRect.top - (this.height / 2);
 				}
 
 				if (helperClass) {
@@ -400,12 +390,12 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 			if (lockToContainerEdges) {
 				const [minLockOffset, maxLockOffset] = this.getLockPixelOffsets();
 				const minOffset = {
-					x: this.halfWidth - minLockOffset.x,
-					y: this.halfHeight - minLockOffset.y
+					x: (this.width / 2) - minLockOffset.x,
+					y: (this.height / 2) - minLockOffset.y
 				};
 				const maxOffset = {
-					x: this.halfWidth - maxLockOffset.x,
-					y: this.halfHeight - maxLockOffset.y
+					x: (this.width / 2) - maxLockOffset.x,
+					y: (this.height / 2) - maxLockOffset.y
 				};
 
 				translate.x = limit(
@@ -449,12 +439,10 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				let {node, edgeOffset} = nodes[i];
 				const index = node.sortableInfo.index;
 				const width = node.offsetWidth;
-				const halfWidth = width / 2;
 				const height = node.offsetHeight;
-				const halfHeight = height / 2;
 				const offset = {
-					width: (this.width > width) ? halfWidth : this.halfWidth,
-					height: (this.height > height) ? halfHeight : this.halfHeight
+					width: (this.width > width) ? (width / 2) : (this.width / 2),
+					height: (this.height > height) ? (height / 2) : (this.height / 2)
 				};
 				let translate = {
 					x: 0,
@@ -580,21 +568,21 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 				y: 10
 			};
 
-			if (translate.y >= this.maxTranslate.y - this.halfHeight) {
+			if (translate.y >= this.maxTranslate.y - (this.height / 2)) {
 				direction.y = 1; // Scroll Down
-				speed.y = acceleration.y * Math.abs((this.maxTranslate.y - this.halfHeight - translate.y) / this.height);
+				speed.y = acceleration.y * Math.abs((this.maxTranslate.y - (this.height / 2) - translate.y) / this.height);
 			}
-			else if (translate.x >= this.maxTranslate.x - this.halfWidth) {
+			else if (translate.x >= this.maxTranslate.x - (this.width / 2)) {
 				direction.x = 1; // Scroll Right
-				speed.x = acceleration.x * Math.abs((this.maxTranslate.x - this.halfWidth - translate.x) / this.width);
+				speed.x = acceleration.x * Math.abs((this.maxTranslate.x - (this.width / 2) - translate.x) / this.width);
 			}
-			else if (translate.y <= this.minTranslate.y + this.halfHeight) {
+			else if (translate.y <= this.minTranslate.y + (this.height / 2)) {
 				direction.y = -1; // Scroll Up
-				speed.y = acceleration.y * Math.abs((translate.y - this.halfHeight - this.minTranslate.y) / this.height);
+				speed.y = acceleration.y * Math.abs((translate.y - (this.height / 2) - this.minTranslate.y) / this.height);
 			}
-			else if (translate.x <= this.minTranslate.x + this.halfWidth) {
+			else if (translate.x <= this.minTranslate.x + (this.width / 2)) {
 				direction.x = -1; // Scroll Left
-				speed.x = acceleration.x * Math.abs((translate.x - this.halfWidth - this.minTranslate.x) / this.width);
+				speed.x = acceleration.x * Math.abs((translate.x - (this.width / 2) - this.minTranslate.x) / this.width);
 			}
 
 			if (this.autoscrollInterval) {
@@ -627,7 +615,33 @@ export default function SortableContainer(WrappedComponent, config = {withRef: f
 		render() {
 			const ref = (config.withRef) ? 'wrappedInstance' : null;
 
-			return <WrappedComponent ref={ref} {...this.props} {...this.state} />;
+			return (
+				<WrappedComponent
+					ref={ref}
+					{...omit(this.props,
+						'contentWindow',
+						'useWindowAsScrollContainer',
+						'distance',
+						'helperClass',
+						'hideSortableGhost',
+						'transitionDuration',
+						'useDragHandle',
+						'pressDelay',
+
+						'shouldCancelStart',
+						'onSortStart',
+						'onSortMove',
+						'onSortEnd',
+
+						'axis',
+						'lockAxis',
+						'lockOffset',
+						'lockToContainerEdges',
+
+						'getContainer',
+					)}
+				/>
+			);
 		}
 	};
 }

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -45,9 +45,9 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 			lockToContainerEdges: false,
 			lockOffset: '50%',
 			getHelperDimensions: ({node}) => ({		
- -				width: node.offsetWidth,		
- -				height: node.offsetHeight		
- -			})
+				width: node.offsetWidth,		
+				height: node.offsetHeight		
+			})
 		};
 
 		static propTypes = {

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import { omit } from 'lodash'
+import omit from 'lodash/omit'
 import invariant from 'invariant';
 
 import Manager from '../Manager';

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -179,7 +179,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 				this.node = node;
 				this.margin = margin;
 				this.width = dimensions.width;	
- -				this.height = dimensions.height;
+ 				this.height = dimensions.height;
 				this.marginOffset = {
 					x: this.margin.left + this.margin.right,
 					y: Math.max(this.margin.top, this.margin.bottom)

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -1,13 +1,14 @@
 import React, {Component, PropTypes} from 'react';
 import {findDOMNode} from 'react-dom';
+import { omit } from 'lodash'
 import invariant from 'invariant';
 
-// Export Higher Order Sortable Element Component
-export default function SortableElement (WrappedComponent, config = {withRef: false}) {
-    return class extends Component {
-        static displayName = (WrappedComponent.displayName) ? `SortableElement(${WrappedComponent.displayName})` : 'SortableElement';
+import { provideDisplayName } from '../utils'
 
-        static WrappedComponent = WrappedComponent;
+// Export Higher Order Sortable Element Component
+export default function sortableElement (WrappedComponent, config = {withRef: false}) {
+    return class extends Component {
+        static displayName = provideDisplayName('sortableElement', WrappedComponent);
 
         static contextTypes = {
             manager: PropTypes.object.isRequired
@@ -75,8 +76,12 @@ export default function SortableElement (WrappedComponent, config = {withRef: fa
 
         render() {
             const ref = (config.withRef) ? 'wrappedInstance' : null;
+
             return (
-                <WrappedComponent ref={ref} {...this.props} />
+                <WrappedComponent
+                    ref={ref}
+                    {...omit(this.props, 'collection', 'disabled', 'index')}
+                />
             );
         }
     };

--- a/src/SortableHandle/index.js
+++ b/src/SortableHandle/index.js
@@ -2,12 +2,12 @@ import React, {Component} from 'react';
 import {findDOMNode} from 'react-dom';
 import invariant from 'invariant';
 
-// Export Higher Order Sortable Element Component
-export default function SortableHandle (WrappedComponent, config = {withRef: false}) {
-    return class extends Component {
-        static displayName = (WrappedComponent.displayName) ? `SortableHandle(${WrappedComponent.displayName})` : 'SortableHandle';
+import { provideDisplayName } from '../utils'
 
-        static WrappedComponent = WrappedComponent;
+// Export Higher Order Sortable Element Component
+export default function sortableHandle (WrappedComponent, config = {withRef: false}) {
+    return class extends Component {
+        static displayName = provideDisplayName('sortableHandle', WrappedComponent)
 
         componentDidMount() {
             let node = findDOMNode(this);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
 export SortableContainer from './SortableContainer';
 export SortableElement from './SortableElement';
 export SortableHandle from './SortableHandle';
+
+export sortableContainer from './SortableContainer';
+export sortableElement from './SortableElement';
+export sortableHandle from './SortableHandle';
+
 export {arrayMove} from './utils';

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,3 +67,9 @@ export function getElementMargin(element) {
         left: getCSSPixelValue(style.marginLeft)
     };
 }
+
+export function provideDisplayName(prefix, Component) {
+    const componentName = Component.displayName || Component.name
+
+    return componentName ? `${prefix}(${componentName})` : prefix;
+}


### PR DESCRIPTION
I did a couple of things in this PR.

- all HOCs are also exported in their lowercase version, i.e. `sortableElement`. This is good style as they are used as functions and not components and all functions which are not used along with `new` should be lowercase
- I removed `getHelperDimensions` as even though it was used, the retrieved values were overwritten anyways.
- I removed the `halfHeight` and `halfWidth` instance properties. Those can be easily computed each time they are needed. Also this reduces the amount of maintenance as you don't need to keep `height` and `width` in sync with their `half` relatives. 