### PR TITLE
fix: workaround for mozilla bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,11 @@ export const events = {
 
 export const vendorPrefix = (function () {
     if (typeof window === 'undefined' || typeof document === 'undefined') return ''; // server environment
-    let styles = window.getComputedStyle(document.documentElement, '');
+    // fix for:
+    //    https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+    //    window.getComputedStyle() returns null inside an iframe with display: none
+    // in this case return an array with a fake mozilla style in it.
+    let styles = window.getComputedStyle(document.documentElement, '') || ['-moz-hidden-iframe'];
     const pre = (Array.prototype.slice
         .call(styles)
         .join('')


### PR DESCRIPTION
Firefox has a fun bug, described here:

https://bugzilla.mozilla.org/show_bug.cgi?id=548397
window.getComputedStyle() returns null inside an iframe with display: none

This causes react-sortable-hoc to throw `TypeError: can't convert null to object`

The workaround is to return an array with a single fake mozilla-prefixed style in it if window.getComputedStyle() returns falsy.