### PR TITLE
perf(lodash): use vanilla omit

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,10 +1,9 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import omit from 'lodash/omit'
 import invariant from 'invariant';
 
 import Manager from '../Manager';
-import {closest, events, vendorPrefix, limit, getElementMargin, provideDisplayName} from '../utils';
+import {closest, events, vendorPrefix, limit, getElementMargin, provideDisplayName, omit} from '../utils';
 
 // Export Higher Order Sortable Container Component
 export default function sortableContainer(WrappedComponent, config = {withRef: false}) {

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -1,9 +1,8 @@
 import React, {Component, PropTypes} from 'react';
 import {findDOMNode} from 'react-dom';
-import omit from 'lodash/omit'
 import invariant from 'invariant';
 
-import { provideDisplayName } from '../utils'
+import { provideDisplayName, omit } from '../utils'
 
 // Export Higher Order Sortable Element Component
 export default function sortableElement (WrappedComponent, config = {withRef: false}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,13 @@ export function arrayMove (arr, previousIndex, newIndex) {
     return array;
 }
 
+export function omit (obj, ...keysToOmit) {
+    return Object.keys(obj).reduce((acc, key) => {
+        if (keysToOmit.indexOf(key) === -1) acc[key] = obj[key];
+        return acc;
+    }, {});
+}
+
 export const events = {
 	start: ['touchstart', 'mousedown'],
 	move: ['touchmove', 'mousemove'],


### PR DESCRIPTION
Fixes #114 

### Limitations
The lodash method accepts keys to omit as many arguments, `_.omit(obj, 'a', 'b', 'c')` or as an array `_.omit(obj, ['a', 'b', 'c'])`.  I've only supported the former as this project only implemented that usage.


### Testing
I noticed there is no test rig.  I added the below snippet to `utils.js` and ran it with `babel-node` to test the util.  I also tested the storybook by hand and all seems well.

```js
const obj = { foo: 'foo', bar: 'bar', baz: 'baz' }

// No omitted keys
console.log(omit(obj))
//=> { foo: 'foo', bar: 'bar', baz: 'baz' }

// Some omitted keys
console.log(omit(obj, 'foo', 'bar'))
//=> { baz: 'baz' }

// All omitted keys
console.log(omit(obj, 'foo', 'bar', 'baz'))
//=> {}

// Omitted non-matching keys
console.log(omit(obj, 'not in there'))
//=> { foo: 'foo', bar: 'bar', baz: 'baz' }
```