### PR TITLE
Removed specific ms case

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,12 +36,7 @@ export const vendorPrefix = (function () {
         .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
     )[1];
 
-    switch (pre) {
-        case 'ms':
-            return 'ms';
-        default:
-            return (pre && pre.length) ? pre[0].toUpperCase() + pre.substr(1) : '';
-    }
+    return (pre && pre.length) ? pre[0].toUpperCase() + pre.substr(1) : '';
 })();
 
 export function closest(el, fn) {


### PR DESCRIPTION
Removed the specific ms case in `vendorPrefix` in `utils.js`. The required return is `Ms` instead of `ms`. Because of this, we don't need a special switch just for `ms`, since the default will return the proper value.

See issue #121 