### PR TITLE
Default to `pointer-events: none` on Sortable helper

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -288,6 +288,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         this.helper.style.width = `${this.width}px`;
         this.helper.style.height = `${this.height}px`;
         this.helper.style.boxSizing = 'border-box';
+        this.helper.style.pointerEvents = 'none';
 
         if (hideSortableGhost) {
           this.sortableGhost = node;


### PR DESCRIPTION
Because... trackpad ninjas.

https://twitter.com/Vjeux/status/840264657424146436