### PR TITLE
Fix collection undefined when used with other drag and drop components

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -21,11 +21,15 @@ export default class Manager {
   }
 
   getActive() {
-    return find(
-      this.refs[this.active.collection],
-      // eslint-disable-next-line eqeqeq
-      ({node}) => node.sortableInfo.index == this.active.index
-    );
+    // check if this.active is defined
+    // see https://github.com/clauderic/react-sortable-hoc/issues/170
+    if (this.active) {
+      return find(
+        this.refs[this.active.collection],
+        // eslint-disable-next-line eqeqeq
+        ({ node }) => node.sortableInfo.index == this.active.index
+      );
+    }
   }
 
   getIndex(collection, ref) {


### PR DESCRIPTION
#170 
Returning find only when `this.active` is not undefined fixes the issue.