### PR TITLE
Remove 'pressThreshold' prop from WrappedComponent

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -777,6 +777,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
             'transitionDuration',
             'useDragHandle',
             'pressDelay',
+	    'pressThreshold',
             'shouldCancelStart',
             'onSortStart',
             'onSortMove',

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -777,7 +777,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
             'transitionDuration',
             'useDragHandle',
             'pressDelay',
-	    'pressThreshold',
+            'pressThreshold',
             'shouldCancelStart',
             'onSortStart',
             'onSortMove',


### PR DESCRIPTION
Hey - great use of HOC here!  Really love it 👍 

'pressThreshold' found it's way into the WrappedComponent's props since it was implemented in 0.6.0.  Small tweak to remove it to prevent polluting. 

Cheers,
Ryan