### PR TITLE
replace React.PropTypes with prop-types package to prevent warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "invariant": "^2.2.1",
-    "lodash": "^4.12.0"
+    "lodash": "^4.12.0",
+    "prop-types": "^15.5.6"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {storiesOf} from '@kadira/storybook';
 import style from './Storybook.scss';

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import invariant from 'invariant';
 

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import invariant from 'invariant';
 


### PR DESCRIPTION
See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes