### PR TITLE
Fixes "Cannot read property 'collection' of null" when distance set and a disabled element is moved

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -20,6 +20,10 @@ export default class Manager {
     }
   }
 
+  isActive() {
+    return this.active;
+  }
+
   getActive() {
     return find(
       this.refs[this.active.collection],

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -205,7 +205,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         if (!distance && (!pressThreshold || pressThreshold && delta >= pressThreshold)) {
           clearTimeout(this.cancelTimer);
           this.cancelTimer = setTimeout(this.cancel, 0);
-        } else if (distance && delta >= distance) {
+        } else if (distance && delta >= distance && this.manager.isActive()) {
           this.handlePress(e);
         }
       }


### PR DESCRIPTION
When the distance prop is set on a SortableContainer and a SortableElement is disabled, trying to move the element results in a "Cannot read property 'collection' of null" error being thrown.

This happens because when trying to sort a disabled element, the manager.active won't get set. In the SortableContainer's handleMove function, if distance is set, handlePress is executed even sorting was attempted on a disabled element.