### PR TITLE
Addressing issue #58 - useWindowAsScrollContainer bug

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -105,12 +105,18 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         useWindowAsScrollContainer,
       } = this.props;
 
+      const findScrollTop = () => {
+        if (this.document.body['scrollTop']) { return this.document.body; }
+        else if (this.document.documentElement['scrollTop']) { return this.document.documentElement; }
+        return;
+      };
+
       this.container = typeof getContainer === 'function'
         ? getContainer(this.getWrappedInstance())
         : findDOMNode(this);
       this.document = this.container.ownerDocument || document;
       this.scrollContainer = useWindowAsScrollContainer
-        ? this.document.body
+        ? findScrollTop()
         : this.container;
       this.contentWindow = typeof contentWindow === 'function'
         ? contentWindow()


### PR DESCRIPTION
Currently useWindowAsScrollContainer doesn't work in firefox and internet explorer 

- I've added a function that checks whether the scroll top property is present on `document.documentElement` or `document.documentBody`. I think the code is slightly messy, but probably preferable to inlining an if statement into the existing ternary operator.

This works in Firefox - I'm not sure whether this also resolves the issue for internet explorer. I will try and determine and get access to a windows machine and test over the weekend. 