### PR TITLE
use scrollContainer as target for cloned node

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -281,7 +281,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
           return (field.value = fields[index] && fields[index].value);
         });
 
-        this.helper = this.document.body.appendChild(clonedNode);
+        this.helper = this.scrollContainer.appendChild(clonedNode);
 
         this.helper.style.position = 'fixed';
         this.helper.style.top = `${this.boundingClientRect.top - margin.top}px`;


### PR DESCRIPTION
@clauderic 
ran into #97, and thought `useWindowAsScrollContainer` would handle the use case where the node is cloned into the body.

so by default, clone to the container itself.