### PR TITLE
Fix remove undefined ref

### DIFF
--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -44,7 +44,7 @@ export default function sortableElement(WrappedComponent, config = {withRef: fal
           this.setDraggable(collection, index);
         }
       } else if (this.props.collection !== nextProps.collection) {
-        this.removeDraggable(this.props.collection);
+        this.ref && this.removeDraggable(this.props.collection);
         this.setDraggable(nextProps.collection, nextProps.index);
       }
     }


### PR DESCRIPTION
When i change "items" data for container which always disabled=true, this error happend
```
Uncaught TypeError: Cannot read property 'indexOf' of undefined
    at Manager.getIndex (Manager.js:66)
    at Manager.remove (Manager.js:40)
    at _class.removeDraggable (index.js:113)
    at _class.componentWillReceiveProps (index.js:82)
```