### PR TITLE
Detect overlap on drop

### DIFF
--- a/src/.stories/Storybook.scss
+++ b/src/.stories/Storybook.scss
@@ -77,10 +77,22 @@
     border-bottom: 0;
 }
 
+.verticalList {
+    display: flex;
+    flex-direction: column;
+    height: 600px;
+    width: 300px;
+}
+
+.verticalItem {
+    height: 100px;
+    flex-shrink: 0;
+}
+
 // Grid
 .grid {
     display: block;
-    width: 130 * 4px;
+    width: 560px;//130 * 4px;
     height: 350px;
     white-space: nowrap;
     border: 0;
@@ -167,6 +179,11 @@
 
 .shrinkedHelper {
     height: 20px !important;
+}
+
+.mergeStyle {
+    border: 1px solid black;
+    background: red;
 }
 
 :global {

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -51,6 +51,10 @@ const SortableList = SortableContainer(({
   items,
   itemClass,
   shouldUseDragHandle,
+  swapThreshold,
+  overlapThreshold,
+  detectOverlap,
+  overlapHelperClass
 }) => {
   return (
     <div className={className}>
@@ -119,11 +123,28 @@ class ListWrapper extends Component {
       onSortStart(this.refs.component);
     }
   };
-  onSortEnd = ({oldIndex, newIndex}) => {
+  onSortEnd = ({oldIndex, newIndex, overlapDetected}) => {
     const {onSortEnd} = this.props;
     const {items} = this.state;
-
-    this.setState({items: arrayMove(items, oldIndex, newIndex), isSorting: false});
+    if (overlapDetected && oldIndex !== newIndex) {
+      const array = items.slice(0);
+      let newElement = array[newIndex];
+      const oldElement = array.splice(oldIndex, 1)[0];
+      if (oldIndex > newIndex) {
+        newElement.value += '_' + oldElement.value;
+      } else {
+        newElement.value = oldElement.value + '_' + newElement.value;
+      }
+      this.setState({
+        items: array,
+        isSorting: false
+      });
+    } else {
+      this.setState({
+        items: arrayMove(items, oldIndex, newIndex),
+        isSorting: false
+      });
+    }
 
     if (onSortEnd) {
       onSortEnd(this.refs.component);
@@ -334,7 +355,7 @@ storiesOf('Basic Configuration', module)
       <div className={style.root}>
         <ListWrapper
           component={SortableList}
-          items={getItems(50, 59)}
+          items={getItems(10, 59)}
           helperClass={style.stylizedHelper}
         />
       </div>
@@ -390,6 +411,20 @@ storiesOf('Basic Configuration', module)
       </div>
     );
   })
+  .add('Vertical', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          component={SortableList}
+          axis={'y'}
+          items={getItems(10, 100)}
+          helperClass={style.stylizedHelper}
+          className={classNames(style.list, style.stylizedList, style.verticalList)}
+          itemClass={classNames(style.stylizedItem, style.verticalItem)}
+        />
+      </div>
+    );
+  })
   .add('Grid', () => {
     return (
       <div className={style.root}>
@@ -404,6 +439,7 @@ storiesOf('Basic Configuration', module)
       </div>
     );
   })
+  
   .add('Nested Lists', () => {
     return (
       <div className={style.root}>
@@ -416,6 +452,62 @@ storiesOf('Basic Configuration', module)
       </div>
     );
   });
+
+storiesOf('Mergeable elements', module)
+  .add('Horizontal', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          component={SortableList}
+          axis={'x'}
+          items={getItems(50, 300)}
+          helperClass={style.stylizedHelper}
+          className={classNames(style.list, style.stylizedList, style.horizontalList)}
+          itemClass={classNames(style.stylizedItem, style.horizontalItem)}
+          overlapHelperClass={ style.mergeStyle }
+          swapThreshold={ 0.75 }
+          overlapThreshold={ 0.9 }
+          detectOverlap={ true }
+        />
+      </div>
+    );
+  })
+  .add('Vertical', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          component={SortableList}
+          axis={'y'}
+          items={getItems(10, 100)}
+          helperClass={style.stylizedHelper}
+          className={classNames(style.list, style.stylizedList, style.verticalList)}
+          itemClass={classNames(style.stylizedItem, style.verticalItem)}
+          overlapHelperClass={ style.mergeStyle }
+          overlapThreshold={ 0.9 }
+          swapThreshold={ 0.75 }
+          detectOverlap={ true }
+        />
+      </div>
+    );
+  })
+  .add('Grid(100)', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          component={SortableList}
+          axis={'xy'}
+          items={getItems(10, 110)}
+          helperClass={style.stylizedHelper}
+          className={classNames(style.list, style.stylizedList, style.grid)}
+          itemClass={classNames(style.stylizedItem, style.gridItem)}
+          swapThreshold={ 0.95 }
+          overlapThreshold={ 0.85 }
+          detectOverlap={ true }
+          overlapHelperClass={ style.mergeStyle }
+        />
+      </div>
+    );
+  })
 
 storiesOf('Advanced', module)
   .add('Press delay (200ms)', () => {

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -41,6 +41,9 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       transitionDuration: 300,
       pressDelay: 0,
       pressThreshold: 5,
+      swapThreshold: 0.5,
+      overlapThreshold: 0.9,
+      detectOverlap: false,
       distance: 0,
       useWindowAsScrollContainer: false,
       hideSortableGhost: true,
@@ -71,6 +74,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       onSortStart: PropTypes.func,
       onSortMove: PropTypes.func,
       onSortEnd: PropTypes.func,
+      detectOverlap: PropTypes.bool,
+      swapThreshold: PropTypes.number,
+      overlapThreshold: PropTypes.number,
+      overlapHelperClass: PropTypes.string,
       shouldCancelStart: PropTypes.func,
       pressDelay: PropTypes.number,
       useDragHandle: PropTypes.bool,
@@ -413,8 +420,9 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       if (typeof onSortEnd === 'function') {
         onSortEnd(
           {
-            oldIndex: this.index,
-            newIndex: this.newIndex,
+            oldIndex        : this.index,
+            newIndex        : this.newIndex,
+            overlapDetected : this.overlapDetected,
             collection,
           },
           e
@@ -548,7 +556,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     }
 
     animateNodes() {
-      const {transitionDuration, hideSortableGhost} = this.props;
+      const {
+        transitionDuration, hideSortableGhost, swapThreshold, overlapHelperClass, detectOverlap,
+        overlapThreshold
+      } = this.props;
       const nodes = this.manager.getOrderedRefs();
       const deltaScroll = {
         left: this.scrollContainer.scrollLeft - this.initialScroll.left,
@@ -559,6 +570,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         top: this.offsetEdge.top + this.translate.y + deltaScroll.top,
       };
       this.newIndex = null;
+      this.overlapDetected = false;
 
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
@@ -566,8 +578,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         const width = node.offsetWidth;
         const height = node.offsetHeight;
         const offset = {
-          width: this.width > width ? width / 2 : this.width / 2,
-          height: this.height > height ? height / 2 : this.height / 2,
+          width: this.width > width ? width : this.width,
+          height: this.height > height ? height : this.height,
         };
         const translate = {
           x: 0,
@@ -610,88 +622,181 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
             `${vendorPrefix}TransitionDuration`
           ] = `${transitionDuration}ms`;
         }
-
         if (this.axis.x) {
           if (this.axis.y) {
-            // Calculations for a grid setup
+            // Calculations for a grid setup    
+            const x_overlap = Math.max(0, Math.min(edgeOffset.left + width, sortingOffset.left + this.width)
+             - Math.max(edgeOffset.left, sortingOffset.left));
+            const y_overlap = Math.max(0, Math.min(edgeOffset.top + height, sortingOffset.top + this.height)
+             - Math.max(edgeOffset.top , sortingOffset.top));
+            const overlapArea = x_overlap * y_overlap;
             if (
-              index < this.index &&
-              (
-                (sortingOffset.left - offset.width <= edgeOffset.left &&
-                sortingOffset.top <= edgeOffset.top + offset.height) ||
-                sortingOffset.top + offset.height <= edgeOffset.top
-              )
+              index < this.index
             ) {
               // If the current node is to the left on the same row, or above the node that's being dragged
               // then move it to the right
-              translate.x = this.width + this.marginOffset.x;
-              if (
-                edgeOffset.left + translate.x >
-                this.containerBoundingRect.width - offset.width
-              ) {
-                // If it moves passed the right bounds, then animate it to the first position of the next row.
-                // We just use the offset of the next node to calculate where to move, because that node's original position
-                // is exactly where we want to go
-                translate.x = nextNode.edgeOffset.left - edgeOffset.left;
-                translate.y = nextNode.edgeOffset.top - edgeOffset.top;
+              if ((sortingOffset.left <= edgeOffset.left + offset.width*(1-swapThreshold) &&
+                sortingOffset.top <= edgeOffset.top + offset.height*(1-swapThreshold)) ||
+                sortingOffset.top + offset.height*(swapThreshold) <= edgeOffset.top) {
+                // Swapping grid left < (1 - swapThreshold)
+                // if there is a major overlap, don't animate other nodes
+                if (this.overlapDetected) continue;
+                // If the current node is to the left on the same row, or above the node that's being dragged
+                // then move it to the right
+                translate.x = this.width + this.marginOffset.x;
+                if (
+                  edgeOffset.left + translate.x >
+                  this.containerBoundingRect.width - offset.width
+                ) {
+                  // If it moves passed the right bounds, then animate it to the first position of the next row.
+                  // We just use the offset of the next node to calculate where to move, because that node's original position
+                  // is exactly where we want to go
+                  translate.x = nextNode.edgeOffset.left - edgeOffset.left;
+                  translate.y = nextNode.edgeOffset.top - edgeOffset.top;
+                }
+                if (this.newIndex === null) {
+                  this.newIndex = index;
+                  this.overlapDetected = false;
+                }
+                node.classList.remove(overlapHelperClass);
+              } else {
+                if (detectOverlap && overlapArea > this.width * this.height*overlapThreshold) {
+                  // Overlapping grid left > overlapThreshold %...Merge components without swapping indexes
+                  this.newIndex = index;
+                  this.overlapDetected = true;
+                  node.classList.add(overlapHelperClass);
+                } else {
+                  // node['+index+'] assuming previous position
+                  node.classList.remove(overlapHelperClass);
+                }
               }
-              if (this.newIndex === null) {
-                this.newIndex = index;
-              }
+              
             } else if (
-              index > this.index &&
-              (
-                (sortingOffset.left + offset.width >= edgeOffset.left &&
-                sortingOffset.top + offset.height >= edgeOffset.top) ||
-                sortingOffset.top + offset.height >= edgeOffset.top + height
-              )
+              index > this.index
             ) {
               // If the current node is to the right on the same row, or below the node that's being dragged
               // then move it to the left
-              translate.x = -(this.width + this.marginOffset.x);
-              if (
-                edgeOffset.left + translate.x <
-                this.containerBoundingRect.left + offset.width
-              ) {
-                // If it moves passed the left bounds, then animate it to the last position of the previous row.
-                // We just use the offset of the previous node to calculate where to move, because that node's original position
-                // is exactly where we want to go
-                translate.x = prevNode.edgeOffset.left - edgeOffset.left;
-                translate.y = prevNode.edgeOffset.top - edgeOffset.top;
+              if ((sortingOffset.left + offset.width*(1-swapThreshold) >= edgeOffset.left &&
+                sortingOffset.top + offset.height*(1-swapThreshold) >= edgeOffset.top) ||
+                sortingOffset.top >= edgeOffset.top + height*swapThreshold) {
+                // Overlapping grid right < (1 - swapThreshold)
+                // if there is a major overlap, don't animate other nodes
+                if (this.overlapDetected) continue;
+                translate.x = -(this.width + this.marginOffset.x);
+                if (
+                  edgeOffset.left + translate.x <
+                  this.containerBoundingRect.left + offset.width
+                ) {
+                  // If it moves passed the left bounds, then animate it to the last position of the previous row.
+                  // We just use the offset of the previous node to calculate where to move, because that node's original position
+                  // is exactly where we want to go
+                  translate.x = prevNode.edgeOffset.left - edgeOffset.left;
+                  translate.y = prevNode.edgeOffset.top - edgeOffset.top;
+                }
+                this.newIndex = index;
+                this.overlapDetected = false;
+                node.classList.remove(overlapHelperClass);
+              } else {
+                if (detectOverlap && overlapArea > this.width * this.height*overlapThreshold) {
+                  // Overlapping grid right > overlapThreshold%...Merge components without swapping indexes
+                  this.newIndex = index;
+                  this.overlapDetected = true;
+                  node.classList.add(overlapHelperClass);
+                } else {
+                  // node['+index+'] assuming previous position
+                  node.classList.remove(overlapHelperClass);
+                }
               }
-              this.newIndex = index;
             }
           } else {
             if (
-              index > this.index &&
-              sortingOffset.left + offset.width >= edgeOffset.left
+              index > this.index
             ) {
-              translate.x = -(this.width + this.marginOffset.x);
-              this.newIndex = index;
-            } else if (
-              index < this.index &&
-              sortingOffset.left <= edgeOffset.left + offset.width
-            ) {
-              translate.x = this.width + this.marginOffset.x;
-              if (this.newIndex == null) {
+              if (sortingOffset.left + offset.width*(1 - swapThreshold) >= edgeOffset.left) {
+                // Swapping rightwards > swapThreshold
+                translate.x = -(this.width + this.marginOffset.x);
                 this.newIndex = index;
+                this.overlapDetected = false;
+                node.classList.remove(overlapHelperClass);
+              } else if (
+                detectOverlap &&
+                sortingOffset.left + offset.width*(swapThreshold) >= edgeOffset.left &&
+                sortingOffset.left + offset.width*(1 - swapThreshold) < edgeOffset.left) {
+                // Overlapping rightwards (1.0-swapThreshold) - swapThreshold...Merge components without swapping indexes
+                this.newIndex = index;
+                this.overlapDetected = true;
+                node.classList.add(overlapHelperClass);
+              } else {
+                // node['+index+'] assuming previous position
+                node.classList.remove(overlapHelperClass);
+              }
+            } else if (
+              index < this.index
+            ) {
+              if (sortingOffset.left <= edgeOffset.left + offset.width*(1 - swapThreshold)) {
+                // Swapping leftwards > swapThreshold
+                translate.x = this.width + this.marginOffset.x;
+                if (this.newIndex == null) {
+                  this.newIndex = index;
+                  this.overlapDetected = false;
+                  node.classList.remove(overlapHelperClass);
+                }
+              } else if(
+                detectOverlap &&
+                sortingOffset.left >= edgeOffset.left + offset.width*(1 - swapThreshold) &&
+                sortingOffset.left <= edgeOffset.left + offset.width*(swapThreshold)) {
+                  // Overlapping leftwards (1.0-swapThreshold) - (swapThreshold)...Merge components without swapping indexes
+                  this.newIndex = index;
+                  this.overlapDetected = true;
+                  node.classList.add(overlapHelperClass);
+              } else {
+                // node['+index+'] assuming previous position
+                node.classList.remove(overlapHelperClass);
               }
             }
           }
         } else if (this.axis.y) {
           if (
-            index > this.index &&
-            sortingOffset.top + offset.height >= edgeOffset.top
+            index > this.index
           ) {
-            translate.y = -(this.height + this.marginOffset.y);
-            this.newIndex = index;
-          } else if (
-            index < this.index &&
-            sortingOffset.top <= edgeOffset.top + offset.height
-          ) {
-            translate.y = this.height + this.marginOffset.y;
-            if (this.newIndex == null) {
+            if (sortingOffset.top + offset.height*(1 - swapThreshold) >= edgeOffset.top) {
+              // Swapping downwards > swapThreshold
+              translate.y = -(this.height + this.marginOffset.y);
               this.newIndex = index;
+              this.overlapDetected = false;
+              node.classList.remove(overlapHelperClass);
+            } else if (
+              detectOverlap &&
+              sortingOffset.top + offset.height*(swapThreshold) >= edgeOffset.top && 
+              sortingOffset.top + offset.height*(1 - swapThreshold) < edgeOffset.top) {
+              // Overlapping downwards (1.0-swapThreshold) - swapThreshold...Merge components without swapping indexes..
+              this.newIndex = index;
+              this.overlapDetected = true;
+              node.classList.add(overlapHelperClass);
+            } else {
+              // node['+index+'] assuming previous position
+              node.classList.remove(overlapHelperClass);
+            }
+          } else if (index < this.index) {
+            if (sortingOffset.top <= edgeOffset.top + offset.height*(1 - swapThreshold)) {
+              // Swapping upwards > swapThreshold%
+              translate.y = this.height + this.marginOffset.y;
+              if (this.newIndex == null) {
+                this.newIndex = index;
+                this.overlapDetected = false;
+                node.classList.remove(overlapHelperClass);
+              }
+            } else if(
+              detectOverlap &&
+              sortingOffset.top >= edgeOffset.top + offset.height*(1 - swapThreshold) &&
+              sortingOffset.top <= edgeOffset.top + offset.height*(swapThreshold)) {
+                // Overlapping upwards (1.0-swapThreshold) - swapThreshold%...Merge components without swapping indexes..` + index
+                this.newIndex = index;
+                this.overlapDetected = true;
+                node.classList.add(overlapHelperClass);
+            } else {
+              // node['+index+'] assuming previous position
+              node.classList.remove(overlapHelperClass);
             }
           }
         }


### PR DESCRIPTION
Hey @clauderic creating this PR with my changes for detecting overlap while dropping. This should handle the use case described in #134. I tried to make it non interfering with existing functionality with boolean flag `detectOverlap`, if this flag is set to false, the hoc should be behave exact same as it was doing before with added advantage that now the amount of drag, which should trigger the swap, is now configurable via `swapThreshold` parameter which default set to 0.5 to mimic the initial behaviour. Other two parameters `overlapThreshold` and `overlapHelperClass` are used to configure the overlap detection use case. Existing code should work without any failure with these changes because by default `detectOverlap` feature is turned off.

Please let me know if I missed any standard/best practice to follow for the PR. And suggest any change that can make the feature more configurable and less interfering with existing functionality. If it needs more documentation, please let me know how can I improve things here.