### PR TITLE
Do not update value of cloned file inputs

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -278,7 +278,9 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         ]; // Convert NodeList to Array
 
         clonedFields.forEach((field, index) => {
-          return (field.value = fields[index] && fields[index].value);
+          if (field.type !== 'file' && fields[index]) {		
+            field.value = fields[index].value;
+          }
         });
 
         this.helper = this.document.body.appendChild(clonedNode);


### PR DESCRIPTION
The value of a file input can only be set to an empty string so we have to skip it.