### PR TITLE
improve handleStart lag by removing unnecessary update/render cycle

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -32,6 +32,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       );
 
       this.state = {};
+      this.sorting = false;
     }
 
     static displayName = provideDisplayName('sortableList', WrappedComponent);
@@ -154,7 +155,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         node &&
         node.sortableInfo &&
         this.nodeIsChild(node) &&
-        !this.state.sorting
+        !this.sorting
       ) {
         const {useDragHandle} = this.props;
         const {index, collection} = node.sortableInfo;
@@ -195,7 +196,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     handleMove = e => {
       const {distance, pressThreshold} = this.props;
 
-      if (!this.state.sorting && this._touched) {
+      if (!this.sorting && this._touched) {
         this._delta = {
           x: this._pos.x - e.pageX,
           y: this._pos.y - e.pageY,
@@ -222,7 +223,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     cancel = () => {
-      if (!this.state.sorting) {
+      if (!this.sorting) {
         clearTimeout(this.pressTimer);
         this.manager.active = null;
       }
@@ -349,10 +350,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
             false
           ));
 
-        this.setState({
-          sorting: true,
-          sortingIndex: index,
-        });
+        this.sorting = true;
+        this.sortingIndex = index;
 
         if (onSortStart) onSortStart({node, index, collection}, e);
       }
@@ -412,10 +411,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       // Update state
       this.manager.active = null;
 
-      this.setState({
-        sorting: false,
-        sortingIndex: null,
-      });
+      this.sorting = false;
+      this.sortingIndex: null;
 
       if (typeof onSortEnd === 'function') {
         onSortEnd(


### PR DESCRIPTION
small tweak: moved .sorting to a local property instead of a this.setState call
could make an immutable scoped var or something, but this works for now.

* * *

I was experiencing some lag on .handleStart due to the setState call on the container
(~30ms with 57 items / ~165ms with 351 items)

by moving this field to a class-level property, rather than Component.state, handleStart now executes in ~1-5ms for me (even with 350 items)


