### PR TITLE
IE 11 fixes for react-sortable-hoc

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -520,8 +520,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         y: offset.y - this.initialOffset.y,
       };
       // Adjust for window scroll
-      translate.y -= ((window.scrollY || window.pageYOffset) - this.initialWindowScroll.top);
-      translate.x -= ((window.scrollX ||  window.pageXOffset)- this.initialWindowScroll.left);
+      translate.y -= (window.pageYOffset - this.initialWindowScroll.top);
+      translate.x -= (window.pageXOffset - this.initialWindowScroll.left);
 
       this.translate = translate;
 
@@ -571,8 +571,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         top: this.offsetEdge.top + this.translate.y + deltaScroll.top,
       };
       const scrollDifference = {
-        top: ((window.scrollY || window.pageYOffset) - this.initialWindowScroll.top),
-        left: ((window.scrollX || window.pageXOffset) - this.initialWindowScroll.left),
+        top: (window.pageYOffset - this.initialWindowScroll.top),
+        left: (window.pageXOffset - this.initialWindowScroll.left),
       };
       this.newIndex = null;
 

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -272,8 +272,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         };
 
         this.initialWindowScroll = {
-          top: window.scrollY,
-          left: window.scrollX,
+          top: (window.scrollY || window.pageYOffset),
+          left: (window.scrollX || window.pageXOffset),
         };
 
         const fields = node.querySelectorAll('input, textarea, select');
@@ -520,8 +520,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         y: offset.y - this.initialOffset.y,
       };
       // Adjust for window scroll
-      translate.y -= (window.scrollY - this.initialWindowScroll.top) || window.pageYOffset;
-      translate.x -= (window.scrollX - this.initialWindowScroll.left) || window.pageXOffset;
+      translate.y -= ((window.scrollY || window.pageYOffset) - this.initialWindowScroll.top);
+      translate.x -= ((window.scrollX ||  window.pageXOffset)- this.initialWindowScroll.left);
 
       this.translate = translate;
 
@@ -571,8 +571,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         top: this.offsetEdge.top + this.translate.y + deltaScroll.top,
       };
       const scrollDifference = {
-        top: (window.scrollY - this.initialWindowScroll.top) || window.pageYOffset,
-        left: (window.scrollX - this.initialWindowScroll.left) || window.pageXOffset,
+        top: ((window.scrollY || window.pageYOffset) - this.initialWindowScroll.top),
+        left: ((window.scrollX || window.pageXOffset) - this.initialWindowScroll.left),
       };
       this.newIndex = null;
 

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -272,8 +272,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         };
 
         this.initialWindowScroll = {
-          top: (window.scrollY || window.pageYOffset),
-          left: (window.scrollX || window.pageXOffset),
+          top: window.pageYOffset,
+          left: window.pageXOffset,
         };
 
         const fields = node.querySelectorAll('input, textarea, select');

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -283,7 +283,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         ]; // Convert NodeList to Array
 
         clonedFields.forEach((field, index) => {
-          if (field.type !== 'file' && fields[index]) {		
+          if (field.type !== 'file' && fields[index]) {
             field.value = fields[index].value;
           }
         });
@@ -513,15 +513,15 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 
     updatePosition(e) {
       const {lockAxis, lockToContainerEdges} = this.props;
-      
+
       const offset = this.getOffset(e);
       const translate = {
         x: offset.x - this.initialOffset.x,
         y: offset.y - this.initialOffset.y,
       };
       // Adjust for window scroll
-      translate.y -= (window.scrollY - this.initialWindowScroll.top);
-      translate.x -= (window.scrollX - this.initialWindowScroll.left);
+      translate.y -= (window.scrollY - this.initialWindowScroll.top) || window.pageYOffset;
+      translate.x -= (window.scrollX - this.initialWindowScroll.left) || window.pageXOffset;
 
       this.translate = translate;
 
@@ -571,8 +571,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         top: this.offsetEdge.top + this.translate.y + deltaScroll.top,
       };
       const scrollDifference = {
-        top: (window.scrollY - this.initialWindowScroll.top),
-        left: (window.scrollX - this.initialWindowScroll.left),
+        top: (window.scrollY - this.initialWindowScroll.top) || window.pageYOffset,
+        left: (window.scrollX - this.initialWindowScroll.left) || window.pageXOffset,
       };
       this.newIndex = null;
 


### PR DESCRIPTION
Added window.pageYOffset and window.pageXOffset to updatePosition and animateNode to allow proper drag and drop animation for Internet Explorer 11