### PR TITLE
Set draggable helper to maximum z-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -297,6 +297,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         this.helper.style.height = `${this.height}px`;
         this.helper.style.boxSizing = 'border-box';
         this.helper.style.pointerEvents = 'none';
+        this.helper.style.zIndex = '2147483647'; // if we don't do this, our helper may be covered up by another DOM object
 
         if (hideSortableGhost) {
           this.sortableGhost = node;


### PR DESCRIPTION
Fixes visual anomaly when SortableContainer is used within material-ui modal dialog (probably other similar situations as well). The draggable element has a lower z-index than the modal dialog, so it becomes hidden behind the dialog.

This solves the issue by setting z-index to the maximum positive value, which should ensure it is always drawn on top of all other elements.
