### PR TITLE
Set contentWindow default ourselves to avoid Jest serialization

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -44,7 +44,6 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       distance: 0,
       useWindowAsScrollContainer: false,
       hideSortableGhost: true,
-      contentWindow: typeof window !== 'undefined' ? window : null,
       shouldCancelStart: function(e) {
         // Cancel sorting if the event target is an `input`, `textarea`, `select` or `option`
         const disabledElements = ['input', 'textarea', 'select', 'option', 'button'];
@@ -100,10 +99,16 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 
     componentDidMount() {
       const {
-        contentWindow,
         getContainer,
         useWindowAsScrollContainer,
       } = this.props;
+
+      /*
+       *  Set our own default rather than using defaultProps because Jest
+       *  snapshots will serialize window, causing a RangeError
+       *  https://github.com/clauderic/react-sortable-hoc/issues/249
+       */
+      const contentWindow = this.props.contentWindow || window;
 
       this.container = typeof getContainer === 'function'
         ? getContainer(this.getWrappedInstance())


### PR DESCRIPTION
This fixes #249

Jest serializes all props in snapshots. The current code sets window by default, which is a huge object. When Jest tries to serialize it, it typically throws `RangeError: Invalid string length` because the process runs out of memory. If you're lucky enough to actually get a test to pass, the snapshot will be around 250mb.

This switches from using defaultProps to setting the default ourselves, so in the test environment there won't be a prop value to serialize.

I confirmed the commonjs version fixes the issue. I'm not sure how to test the es6/umd versions. `npm test` passes.