### PR TITLE
Revert "Update Code Sponsor link position"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 ### Examples available here: <a href="#">http://clauderic.github.io/react-sortable-hoc/</a>
 
+<a href="https://app.codesponsor.io/link/oN9PDWZz8fQcbh9sxpDEUvD5/clauderic/react-sortable-hoc" rel="nofollow"><img src="https://app.codesponsor.io/embed/oN9PDWZz8fQcbh9sxpDEUvD5/clauderic/react-sortable-hoc.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>
+
 Features
 ---------------
 * **Higher Order Components** – Integrates with your existing components
@@ -183,5 +185,3 @@ Please do not use the issue tracker for personal support requests. Instead, use 
 Contributions
 ------------
 Yes please! Feature requests / pull requests are welcome.
-
-<a href="https://app.codesponsor.io/link/oN9PDWZz8fQcbh9sxpDEUvD5/clauderic/react-sortable-hoc" rel="nofollow" target="_blani"><img src="https://app.codesponsor.io/embed/oN9PDWZz8fQcbh9sxpDEUvD5/clauderic/react-sortable-hoc.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>


### PR DESCRIPTION
Since the README file is quite long, not sure putting the sponsor link at the bottom makes sense. Reverts clauderic/react-sortable-hoc#276