### PR TITLE
Fix cancellation of handlePress while scrolling on mobile

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -149,8 +149,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 
       this._touched = true;
       this._pos = {
-        x: e.pageX,
-        y: e.pageY,
+        x: e.changedTouches ? e.changedTouches[0].pageX : e.pageX,
+        y: e.changedTouches ? e.changedTouches[0].pageY : e.pageY,
       };
 
       const node = closest(e.target, el => el.sortableInfo != null);
@@ -202,8 +202,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 
       if (!this.state.sorting && this._touched) {
         this._delta = {
-          x: this._pos.x - e.pageX,
-          y: this._pos.y - e.pageY,
+          x: this._pos.x - (e.changedTouches ? e.changedTouches[0].pageX : e.pageX),
+          y: this._pos.y - (e.changedTouches ? e.changedTouches[0].pageY : e.pageY),
         };
         const delta = Math.abs(this._delta.x) + Math.abs(this._delta.y);
 


### PR DESCRIPTION
Currently, if you touch the screen and then scroll while keeping the finger on the screen, sortable item sorting gets started. This PR fixes this issue. On mobile, TouchEvent does not have pageX, pageY. Therefore, this._delta.x and this._delta.y are NaNs.

I could reproduce this bug with this http://clauderic.github.io/react-sortable-hoc/#/advanced/activate-onpress-200ms?_k=m9py9o example in Firefox. Couldn't reproduce this in Chrome. For some reason
```
this.pressTimer = setTimeout(
              () => this.handlePress(e),
              this.props.pressDelay
            );
```
gets postponed until one stops scrolling and removes finger off the screen.

However, this issue is reproducible in Chrome in the application I am building, and this timeout function is not postponed in my application. It may be a Chrome bug or a feature such as https://bugs.chromium.org/p/chromium/issues/detail?id=567800