### PR TITLE
Stub out Virtualized Grid Example

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -8,6 +8,7 @@ import VirtualList from 'react-tiny-virtual-list';
 import {
   defaultTableRowRenderer,
   Column,
+  Grid,
   Table,
   List,
 } from 'react-virtualized';
@@ -218,7 +219,55 @@ class VirtualizedListWrapper extends Component {
   }
 }
 
+class VirtualizedGridWrapper extends Component {
+  render() {
+    const {
+      className,
+      items,
+      height,
+      width,
+      itemHeight,
+      itemClass,
+    } = this.props;
+
+    const COLUMN_COUNT = 3;
+    const length = items.length;
+    const rowCount = Math.ceil(length / COLUMN_COUNT);
+
+    return (
+      <Grid
+        axis="xy"
+        cellRenderer={({columnIndex, key, rowIndex, style}) => {
+          const datumIndex = (rowIndex * COLUMN_COUNT) + columnIndex;
+
+          const {value, height} = items[datumIndex];
+          return (
+            <Item
+              className={itemClass}
+              columnIndex={columnIndex}
+              height={height}
+              index={datumIndex}
+              key={key}
+              style={style}
+              value={value}
+            />
+          );
+        }}
+        className={className}
+        columnCount={COLUMN_COUNT}
+        columnWidth={130}
+        rowCount={rowCount}
+        rowHeight={itemHeight}
+        width={width}
+        height={height}
+      />
+    );
+  }
+}
+
 const SortableVirtualizedList = SortableContainer(VirtualizedListWrapper, {withRef: true});
+const SortableVirtualizedGrid = SortableContainer(VirtualizedGridWrapper, {withRef: true});
+
 const SortableTable = SortableContainer(Table, {withRef: true});
 const SortableRowRenderer = SortableElement(defaultTableRowRenderer);
 
@@ -396,7 +445,7 @@ storiesOf('Basic Configuration', module)
         <ListWrapper
           component={SortableList}
           axis={'xy'}
-          items={getItems(10, 110)}
+          items={getItems(50, 110)}
           helperClass={style.stylizedHelper}
           className={classNames(style.list, style.stylizedList, style.grid)}
           itemClass={classNames(style.stylizedItem, style.gridItem)}
@@ -562,6 +611,22 @@ storiesOf('react-virtualized', module)
             vs.recomputeRowHeights();
             instance.forceUpdate();
           }}
+        />
+      </div>
+    );
+  })
+  .add('Virtualized Grid', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          axis={'xy'}
+          className={classNames(style.list, style.stylizedList, style.grid)}
+          component={SortableVirtualizedGrid}
+          helperClass={style.stylizedHelper}
+          items={getItems(500, 110)}
+          itemClass={classNames(style.stylizedItem, style.gridItem)}
+          itemHeight={110}
+          width={420}
         />
       </div>
     );


### PR DESCRIPTION
Hi @clauderic, I am trying to get this working with react-virtualized `<Grid>`. I  am running into an issue I'm hoping you can spot and address. In hopes of tempting you to help me out, I've stubbed out an illustrative example in the storybook demo page 😸  which I hope can be tweaked and added to the repo for future purposes.

Basically, everything works, except that drag-scrolling down long distances generates errors in the console. The error is easy to reproduce. Run the demo locally, click on the . "Virtualized Grid" example, and drag scroll down, hard and fast. The error happens here:

https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L681

I would be extremely grateful for a fix to this. Thanks for an awesome library.