### PR TITLE
Text wraps on dragging

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -364,7 +364,7 @@ storiesOf('Basic Configuration', module)
     );
   })
   .add('Elements that shrink', () => {
-    const getHelperDimensions = ({node}) => ({height: 20, width: node.offsetWidth});
+    const getHelperDimensions = ({node}) => ({height: 20, width: node.getBoundingClientRect().width});
     return (
       <div className={style.root}>
         <ListWrapper

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -55,8 +55,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       lockToContainerEdges: false,
       lockOffset: '50%',
       getHelperDimensions: ({node}) => ({
-        width: node.offsetWidth,
-        height: node.offsetHeight,
+        width: node.getBoundingClientRect().width,
+        height: node.getBoundingClientRect().height,
       }),
     };
 
@@ -584,8 +584,8 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const index = node.sortableInfo.index;
-        const width = node.offsetWidth;
-        const height = node.offsetHeight;
+        const width = node.getBoundingClientRect().width;
+        const height = node.getBoundingClientRect().height;
         const offset = {
           width: this.width > width ? width / 2 : this.width / 2,
           height: this.height > height ? height / 2 : this.height / 2,


### PR DESCRIPTION
In this example i'm dragging the first item and the text inside automatically wraps:

![example](https://user-images.githubusercontent.com/5671564/37289451-fb5dd6d4-2609-11e8-87dd-c7546f932118.png)

The problem is that the node.offsetWidth returns 131 pixels instead of 131.16.

It can be solved by replacing node.offsetWidth and node.offsetHeight with node.getBoundingClientRect().width and node.getBoundingClientRect().height