### PR TITLE
Fix issues with removeEventListener when container is undefined

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -134,11 +134,13 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     }
 
     componentWillUnmount() {
-      for (const key in this.events) {
-        if (this.events.hasOwnProperty(key)) {
-          events[key].forEach(eventName =>
-            this.container.removeEventListener(eventName, this.events[key])
-          );
+      if (this.container) {
+        for (const key in this.events) {
+          if (this.events.hasOwnProperty(key)) {
+            events[key].forEach(eventName =>
+              this.container.removeEventListener(eventName, this.events[key])
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes potential issues with calling `removeEventListeners` on `componentWillUnmount` if the `container` node has already unmounted