### PR TITLE
Fix scrolling issues on mobile with anchor tag elements

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -13,6 +13,7 @@ import {
   getElementMargin,
   getLockPixelOffset,
   getPosition,
+  isTouchEvent,
   provideDisplayName,
   omit,
 } from '../utils';
@@ -182,7 +183,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
 				 * prevent subsequent 'mousemove' events from being fired
 				 * (see https://github.com/clauderic/react-sortable-hoc/issues/118)
 				 */
-        if (event.target.tagName.toLowerCase() === 'a') {
+        if (!isTouchEvent(event) && event.target.tagName.toLowerCase() === 'a') {
           event.preventDefault();
         }
 
@@ -748,7 +749,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         config.withRef,
         'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call'
       );
-      
+
       return this.refs.wrappedInstance;
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,6 +102,14 @@ export function getPosition(event) {
   }
 }
 
+export function isTouchEvent(event) {
+  return (
+    event instanceof TouchEvent ||
+    event.touches && event.touches.length ||
+    event.changedTouches && event.changedTouches.length
+  );
+}
+
 export function getEdgeOffset(node, parent, offset = {top: 0, left: 0}) {
   // Get the actual offsetTop / offsetLeft value, no matter how deep the node is nested
   if (node) {


### PR DESCRIPTION
This PR fixes an issue where scroll events would be cancelled on touch devices due to code aimed at fixing issues on desktop with anchor tags as sortable elements.