### PR TITLE
Replace imports from react-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Usage
 
 ```js
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
 
 const SortableItem = SortableElement(({value}) =>
@@ -80,7 +80,7 @@ class SortableComponent extends Component {
   }
 }
 
-render(<SortableComponent/>, document.getElementById('root'));
+ReactDOM.render(<SortableComponent/>, document.getElementById('root'));
 ```
 That's it! React Sortable does not come with any styles by default, since it's meant to enhance your existing components.
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
 
 const SortableItem = SortableElement(({value}) => <li>{value}</li>);
@@ -28,4 +28,4 @@ class SortableComponent extends Component {
   }
 }
 
-render(<SortableComponent />, document.getElementById('root'));
+ReactDOM.render(<SortableComponent />, document.getElementById('root'));

--- a/examples/drag-handle.js
+++ b/examples/drag-handle.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {
   SortableContainer,
   SortableElement,
@@ -46,4 +46,4 @@ class SortableComponent extends Component {
   }
 }
 
-render(<SortableComponent />, document.getElementById('root'));
+ReactDOM.render(<SortableComponent />, document.getElementById('root'));

--- a/examples/infinite-list.js
+++ b/examples/infinite-list.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
 import Infinite from 'react-infinite';
 
@@ -46,4 +46,4 @@ class SortableComponent extends Component {
   }
 }
 
-render(<SortableComponent />, document.getElementById('root'));
+ReactDOM.render(<SortableComponent />, document.getElementById('root'));

--- a/examples/virtual-list.js
+++ b/examples/virtual-list.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
 import {List} from 'react-virtualized';
 
@@ -81,4 +81,4 @@ class SortableComponent extends Component {
   }
 }
 
-render(<SortableComponent />, document.getElementById('root'));
+ReactDOM.render(<SortableComponent />, document.getElementById('root'));

--- a/examples/virtual-table-columns.js
+++ b/examples/virtual-table-columns.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {Table, Column} from 'react-virtualized';
 import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc';
 import 'react-virtualized/styles.css';
@@ -73,4 +73,4 @@ class TableWithSortableColumns extends Component {
   }
 }
 
-render(<TableWithSortableColumns />, document.getElementById('root'));
+ReactDOM.render(<TableWithSortableColumns />, document.getElementById('root'));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill';
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM from 'react-dom';
 import {SortableContainer, SortableElement, arrayMove} from './src/index';
 import range from 'lodash/range';
 import random from 'lodash/random';
@@ -59,6 +59,6 @@ class Example extends Component {
     }
 }
 
-render(<Example />,
+ReactDOM.render(<Example />,
   document.getElementById('root')
 )

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {findDOMNode} from 'react-dom';
+import ReactDOM from 'react-dom';
 import invariant from 'invariant';
 
 import Manager from '../Manager';
@@ -757,7 +757,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       const {getContainer} = this.props;
 
       if (typeof getContainer !== 'function') {
-        return findDOMNode(this);
+        return ReactDOM.findDOMNode(this);
       }
 
       return getContainer(config.withRef ? this.getWrappedInstance() : undefined);

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {findDOMNode} from 'react-dom';
+import ReactDOM from 'react-dom';
 import invariant from 'invariant';
 
 import {provideDisplayName, omit} from '../utils';
@@ -56,7 +56,7 @@ export default function sortableElement(WrappedComponent, config = {withRef: fal
     }
 
     setDraggable(collection, index) {
-      const node = (this.node = findDOMNode(this));
+      const node = (this.node = ReactDOM.findDOMNode(this));
 
       node.sortableInfo = {
         index,

--- a/src/SortableHandle/index.js
+++ b/src/SortableHandle/index.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {findDOMNode} from 'react-dom';
+import ReactDOM from 'react-dom';
 import invariant from 'invariant';
 
 import {provideDisplayName} from '../utils';
@@ -10,7 +10,7 @@ export default function sortableHandle(WrappedComponent, config = {withRef: fals
     static displayName = provideDisplayName('sortableHandle', WrappedComponent);
 
     componentDidMount() {
-      const node = findDOMNode(this);
+      const node = ReactDOM.findDOMNode(this);
       node.sortableHandle = true;
     }
 


### PR DESCRIPTION
react-dom exports using CommonJs modules. When building with Rollup, I get the error below because the way the imports are written are not compatible with ES6 modules.

The error when building with Rollup and Babel 6:
[!] Error: 'findDOMNode' is not exported by node_modules/react-dom/index.js

More info: https://blog.kentcdodds.com/misunderstanding-es6-modules-upgrading-babel-tears-and-a-solution-ad2d5ab93ce0