### PR TITLE
Clone canvas contents with drawImage (#395)

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -289,6 +289,7 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
           left: window.pageXOffset,
         };
 
+        const canvases = node.querySelectorAll('canvas');
         const fields = node.querySelectorAll('input, textarea, select');
         const clonedNode = node.cloneNode(true);
         const clonedFields = [
@@ -299,6 +300,16 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
           if (field.type !== 'file' && fields[index]) {
             field.value = fields[index].value;
           }
+        });
+
+        const clonedCanvases = [
+          ...clonedNode.querySelectorAll('canvas'),
+        ]; // Convert NodeList to Array
+
+        clonedCanvases.forEach((clonedCanvas, index) => {
+          const oldCanvas = canvases[index];
+          var clonedCanvasCtx = clonedCanvas.getContext('2d');
+          clonedCanvasCtx.drawImage(oldCanvas, 0, 0);
         });
 
         this.helper = this.document.body.appendChild(clonedNode);


### PR DESCRIPTION
When DOM nodes are cloned with Node.cloneNode, the contents of
<canvas> elements are lost.  This makes canvas elements lose their
contents while dragged.

On losing <canvas> contents: "Cloning a node copies all of its
attributes and their values, including intrinsic (in–line)
listeners. It does not copy event listeners added using
addEventListener() or those assigned to element properties
(e.g. node.onclick = fn). _Moreover, for a <canvas> element, the
painted image is not copied._"
(https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode,
emphasis mine)

To fix this, copy the painted image from the old canvas into the new
cloned canvas with drawImage.