### PR TITLE
Solves #428 - Different height items cause wrong sorting animation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# @adrianhelvik/react-sortable-hoc
+
+This is a fork of react-sortable-hoc by clauderic as the repo isn't frequently maintained.
+I have purposefully not changed more things than necessary.
+
 # React Sortable (HOC)
 > A set of higher-order components to turn any list into an animated, touch-friendly, sortable list.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-sortable-hoc",
-  "version": "0.8.3",
+  "name": "@adrianhelvik/react-sortable-hoc",
+  "version": "1.0.0",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -540,11 +540,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const index = node.sortableInfo.index;
-        const width = node.offsetWidth;
         const height = node.offsetHeight;
         const offset = {
-          width: this.width > width ? width / 2 : this.width / 2,
-          height: this.height > height ? height / 2 : this.height / 2,
+          width: this.width / 2,
+          height: this.height / 2,
         };
 
         const translate = {


### PR DESCRIPTION
Please consider why the target node was used as a reference node for the height. It does not make sense to me, but there might be something I am overlooking.