### PR TITLE
Solves #428 - Different height items cause wrong sorting animation order

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -540,11 +540,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const index = node.sortableInfo.index;
-        const width = node.offsetWidth;
         const height = node.offsetHeight;
         const offset = {
-          width: this.width > width ? width / 2 : this.width / 2,
-          height: this.height > height ? height / 2 : this.height / 2,
+          width: this.width / 2,
+          height: this.height / 2,
         };
 
         const translate = {


### PR DESCRIPTION
Please consider why the target node was used as a reference node for the height. It does not make sense to me, but there might be something I am overlooking.

Before this pull request is merged I have created a clone at `@adrianhelvik/react-sortable-hoc`

Cheers!