### PR TITLE
Fix the dimension calculation

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -255,8 +255,12 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
         } = this.props;
         const {node, collection} = active;
         const {index} = node.sortableInfo;
-        const margin = getElementMargin(node);
 
+        if (helperClass) {
+          node.classList.add(...helperClass.split(' '));
+        }
+
+        const margin = getElementMargin(node);
         const containerBoundingRect = this.container.getBoundingClientRect();
         const dimensions = getHelperDimensions({index, node, collection});
 
@@ -344,10 +348,6 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
             this.height / 2;
         }
 
-        if (helperClass) {
-          this.helper.classList.add(...helperClass.split(' '));
-        }
-
         this.listenerNode = event.touches ? node : this.contentWindow;
         events.move.forEach(eventName =>
           this.listenerNode.addEventListener(
@@ -387,8 +387,13 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     handleSortEnd = event => {
-      const {hideSortableGhost, onSortEnd} = this.props;
+      const {hideSortableGhost, onSortEnd, helperClass} = this.props;
       const {collection} = this.manager.active;
+
+      const active = this.manager.getActive();
+      if (active && helperClass) {
+        active.node.classList.remove(...helperClass.split(' '));
+      }
 
       // Remove the event listeners if the node is still in the DOM
       if (this.listenerNode) {


### PR DESCRIPTION
Fix the dimension calculation when helperClass change the size of the node.

### Before
![2018-11-19 18 02 12](https://user-images.githubusercontent.com/4728325/48740378-49266c00-ec25-11e8-958c-af0d8e2a3eef.gif)

### After
![2018-11-19 18 02 56](https://user-images.githubusercontent.com/4728325/48740407-60fdf000-ec25-11e8-9d96-52d2599db8d9.gif)

I tried to add the helperClass only on the clone element but we can't because the hidden element will still take the same height.

Let me know if you need more detail ✌️ 