### PR TITLE
Fix a bug when you use SortableHandle and distance prop.

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -225,18 +225,16 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     handleEnd = () => {
-      const {distance} = this.props;
-
       this._touched = false;
-
-      if (!distance) {
-        this.cancel();
-      }
+      this.cancel();
     };
 
     cancel = () => {
+      const { distance } = this.props;
       if (!this.state.sorting) {
-        clearTimeout(this.pressTimer);
+        if (!distance) {
+          clearTimeout(this.pressTimer);
+        }
         this.manager.active = null;
       }
     };

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -230,8 +230,10 @@ export default function sortableContainer(WrappedComponent, config = {withRef: f
     };
 
     cancel = () => {
-      const { distance } = this.props;
-      if (!this.state.sorting) {
+      const {distance} = this.props;
+      const {sorting} = this.state;
+
+      if (!sorting) {
         if (!distance) {
           clearTimeout(this.pressTimer);
         }


### PR DESCRIPTION
I found an issue when you set a distance and you use `SortableHandle`.
After you click on the handle, you are able to drag the element from everywhere inside the `li`.

| Before        | After           |
| ------------- |:-------------:|
|![2018-11-20 19 39 58](https://user-images.githubusercontent.com/4728325/48811535-3cc11280-ecfc-11e8-87ea-4496b6426cfb.gif) | ![2018-11-20 19 42 48](https://user-images.githubusercontent.com/4728325/48811957-18fecc00-ecfe-11e8-87e5-64f2b935e862.gif) |


So the main problem comes from [here](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L179). During the handleStart we set the manager.
But inside the `handleEnd` we never unset the manager if the distance prop was set. You can check the code [here](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L227). It's true that we shouldn't call `clearTimeout(this.pressTimer);` when you had set a distance because you can't set both properties (distance | pressDelay). 

Feel free to ask me for changes if you find a better approach ✌️