### PR TITLE
Added CSS grid support

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -9,6 +9,7 @@ import {
   events,
   vendorPrefix,
   limit,
+  getContainerGridGap,
   getEdgeOffset,
   getElementMargin,
   getLockPixelOffset,
@@ -309,17 +310,19 @@ export default function sortableContainer(
         }
 
         const margin = getElementMargin(node);
+        const gridGap = getContainerGridGap(this.container);
 
         const containerBoundingRect = this.container.getBoundingClientRect();
         const dimensions = getHelperDimensions({index, node, collection});
 
         this.node = node;
         this.margin = margin;
+        this.gridGap = gridGap;
         this.width = dimensions.width;
         this.height = dimensions.height;
         this.marginOffset = {
-          x: this.margin.left + this.margin.right,
-          y: Math.max(this.margin.top, this.margin.bottom),
+          x: this.margin.left + this.margin.right + this.gridGap.x,
+          y: Math.max(this.margin.top, this.margin.bottom, this.gridGap.y),
         };
         this.boundingClientRect = node.getBoundingClientRect();
         this.containerBoundingRect = containerBoundingRect;

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,6 +137,19 @@ export function getEdgeOffset(node, parent, offset = {top: 0, left: 0}) {
   return getEdgeOffset(node.parentNode, parent, nodeOffset);
 }
 
+export function getContainerGridGap(element) {
+  const style = window.getComputedStyle(element);
+
+  if (style.display === 'grid') {
+    return {
+      x: getPixelValue(style.gridColumnGap),
+      y: getPixelValue(style.gridRowGap),
+    };
+  }
+
+  return { x: 0, y: 0 };
+}
+
 export function getLockPixelOffset({lockOffset, width, height}) {
   let offsetX = lockOffset;
   let offsetY = lockOffset;

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,7 +147,7 @@ export function getContainerGridGap(element) {
     };
   }
 
-  return { x: 0, y: 0 };
+  return {x: 0, y: 0};
 }
 
 export function getLockPixelOffset({lockOffset, width, height}) {


### PR DESCRIPTION
Hey, cool library!
I just started using `react-sortable-hoc` and I noticed it doesn't work well with CSS grid (because of the grid gaps).     
In [Another Tab](https://github.com/mmazzarolo/chrome-another-tab) we're using CSS grid to show the bookmarks, so I investigated a little and I've found an open PR (#289) that adds the CSS grid support and, after updating it to the current state of the `master` branch, I tried it on the project and it has been working really well so far.  

Since the build process of this library is not running on post-install implementing it from a branch is not straight-forward, so I'm re-submitting the updated PR.  

All the work was done in #289 though, I just merely updated it (might need a bit more testing?). 

FYI here is a GIFs of the PR result on a CSS grid layout:  
![2019-01-19 19 48 59](https://user-images.githubusercontent.com/9536354/51431107-92df0300-1c24-11e9-99aa-c8e80c8443ef.gif)
