### PR TITLE
fix: update helperContainer prop type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,6 +43,8 @@ export type ContainerGetter = (
   element: React.ReactElement<any>,
 ) => HTMLElement | Promise<HTMLElement>;
 
+export type HelperContainerGetter = () => HTMLElement;
+
 export interface Dimensions {
   width: number;
   height: number;
@@ -69,7 +71,7 @@ export interface SortableContainerProps {
   lockOffset?: Offset | [Offset, Offset];
   getContainer?: ContainerGetter;
   getHelperDimensions?: (sort: SortStart) => Dimensions;
-  helperContainer?: HTMLElement;
+  helperContainer?: HTMLElement | HelperContainerGetter;
 }
 
 export interface SortableElementProps {


### PR DESCRIPTION
This PR fixes the TypeScript types definition for the `helperContainer` prop. `1.5.0` introduced the ability to pass a function to the `helperContainer` prop, but the type definitions were not updated.