### PR TITLE
fix: omit helperContainer prop from WrappedComponent

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -879,6 +879,7 @@ export default function sortableContainer(
             'lockToContainerEdges',
             'getContainer',
             'getHelperDimensions',
+            'helperContainer',
           )}
         />
       );


### PR DESCRIPTION
The `helperContainer` prop needs to be included in the list of omitted props when spreading props onto `WrappedComponent`. Otherwise, passing a DOM element string to `SortableContainer` will cause React to complain about the prop. Example:

```jsx
const SortableTBody = SortableContainer('tbody')
```
Using `<SortableTBody/>` will generate the following:
```
Warning: React does not recognize the `helperContainer` prop on a DOM element. [...]
```

Thanks for adding the `helperContainer` feature, it allowed me to simplify some of my code!