### PR TITLE
fix: omit disableAutoscroll prop

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -915,6 +915,7 @@ export default function sortableContainer(
             'getContainer',
             'getHelperDimensions',
             'helperContainer',
+            'disableAutoscroll',
           )}
         />
       );


### PR DESCRIPTION
Same as with the `helperContainer` addition... the added prop needs to be explicitly omitted from those that are passed through.

I guess this repo would benefit from having automated tests. ;) To be clear, that's not meant as a criticism — I know we're all strapped for time and I could create a PR adding tests if I wanted to. I'm operating under the same constraint.