### PR TITLE
Improve scroll container behaviour

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -16,6 +16,7 @@ import {
   isTouchEvent,
   provideDisplayName,
   omit,
+  getScrollingParent,
 } from '../utils';
 
 export default function sortableContainer(
@@ -145,9 +146,10 @@ export default function sortableContainer(
 
         this.contentWindow =
           typeof contentWindow === 'function' ? contentWindow() : contentWindow;
+
         this.scrollContainer = useWindowAsScrollContainer
           ? this.document.scrollingElement || this.document.documentElement
-          : this.container;
+          : getScrollingParent(this.container) || this.container;
 
         for (const key in this.events) {
           if (this.events.hasOwnProperty(key)) {
@@ -318,7 +320,7 @@ export default function sortableContainer(
 
         const margin = getElementMargin(node);
 
-        const containerBoundingRect = this.container.getBoundingClientRect();
+        const containerBoundingRect = this.scrollContainer.getBoundingClientRect();
         const dimensions = getHelperDimensions({index, node, collection});
 
         this.node = node;
@@ -341,8 +343,8 @@ export default function sortableContainer(
         this.offsetEdge = getEdgeOffset(node, this.container);
         this.initialOffset = getPosition(event);
         this.initialScroll = {
-          top: this.container.scrollTop,
-          left: this.container.scrollLeft,
+          top: this.scrollContainer.scrollTop,
+          left: this.scrollContainer.scrollLeft,
         };
 
         this.initialWindowScroll = {
@@ -587,8 +589,8 @@ export default function sortableContainer(
       const {transitionDuration, hideSortableGhost, onSortOver} = this.props;
       const nodes = this.manager.getOrderedRefs();
       const containerScrollDelta = {
-        left: this.container.scrollLeft - this.initialScroll.left,
-        top: this.container.scrollTop - this.initialScroll.top,
+        left: this.scrollContainer.scrollLeft - this.initialScroll.left,
+        top: this.scrollContainer.scrollTop - this.initialScroll.top,
       };
       const sortingOffset = {
         left:

--- a/src/utils.js
+++ b/src/utils.js
@@ -174,24 +174,22 @@ export function getLockPixelOffset({lockOffset, width, height}) {
   };
 }
 
-export function getScrollingParent(el) {
-  try {
-    const {
-      overflow,
-      overflowX,
-      overflowY,
-    } = window.getComputedStyle(el);
+function isScrollable(el) {
+  const computedStyle = window.getComputedStyle(el);
+  const overflowRegex = /(auto|scroll)/;
+  const properties = ['overflow', 'overflowX', 'overflowY'];
 
-    if (
-      overflow === 'auto' || overflow === 'scroll' ||
-      overflowX === 'auto' || overflowX === 'scroll' ||
-      overflowY === 'auto' || overflowY === 'scroll'
-    ) {
-      return el;
-    } else {
-      return getScrollingParent(el.parentNode);
-    }
-  } catch (err) {
+  return properties.find((property) =>
+    overflowRegex.test(computedStyle[property]),
+  );
+}
+
+export function getScrollingParent(el) {
+  if (!el) {
     return null;
+  } else if (isScrollable(el)) {
+    return el;
+  } else {
+    return getScrollingParent(el.parentNode);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,16 +175,23 @@ export function getLockPixelOffset({lockOffset, width, height}) {
 }
 
 export function getScrollingParent(el) {
-  let overflow;
   try {
-    overflow = window.getComputedStyle(el).overflow;
+    const {
+      overflow,
+      overflowX,
+      overflowY,
+    } = window.getComputedStyle(el);
+
+    if (
+      overflow === 'auto' || overflow === 'scroll' ||
+      overflowX === 'auto' || overflowX === 'scroll' ||
+      overflowY === 'auto' || overflowY === 'scroll'
+    ) {
+      return el;
+    } else {
+      return getScrollingParent(el.parentNode);
+    }
   } catch (err) {
     return null;
-  }
-
-  if (overflow === 'auto' || overflow === 'scroll') {
-    return el;
-  } else {
-    return getScrollingParent(el.parentNode);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,3 +173,18 @@ export function getLockPixelOffset({lockOffset, width, height}) {
     y: offsetY,
   };
 }
+
+export function getScrollingParent(el) {
+  let overflow;
+  try {
+    overflow = window.getComputedStyle(el).overflow;
+  } catch (err) {
+    return null;
+  }
+
+  if (overflow === 'auto' || overflow === 'scroll') {
+    return el;
+  } else {
+    return getScrollingParent(el.parentNode);
+  }
+}


### PR DESCRIPTION
[Subissue of #501](https://github.com/clauderic/react-sortable-hoc/pull/501#discussion_r264287089)

This PR improves the scroll container default by checking the element's ancestors for appropriate scrolling styles. It also replaces references to `this.container` with those to `this.scrollContainer` in the autoscrolling logic.

This mainly impacts the nested list use case; other use cases (including window as scroll container) should remain unaffected.

If this gets merged in, I'll put up a commit in #501 to consolidate the changes.

_Sorry for the terrible GIF quality_

| Before | After |
|---|---|
| ![masterscroll](https://user-images.githubusercontent.com/46533681/54211581-f6184380-44b7-11e9-87ae-1c6f9ff57fda.gif) | ![sortingscroll](https://user-images.githubusercontent.com/46533681/54211601-fadcf780-44b7-11e9-85a5-2edcf17b0cc5.gif)
