### PR TITLE
fixed cloning canvas context of dragged items

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -284,7 +284,7 @@ export default function sortableContainer(
 
           if (field.tagName === NodeType.Canvas) {
             const destCtx = field.getContext('2d');
-            destCtx.drawImage(fields[index], 0, 0);
+            destCtx.drawImage(fields[i], 0, 0);
           }
         });
 


### PR DESCRIPTION
Hello, after installing the last release of the package I've encountered problem with sorting canvas items. After some debugging I found out that the problem is in copying canvas context on sort (it gets elements from array of items with the wrong index).