### PR TITLE
Fix IE11 "Possible Unhandled Promise Rejection" error

### DIFF
--- a/src/Manager/index.js
+++ b/src/Manager/index.js
@@ -22,10 +22,16 @@ export default class Manager {
   }
 
   getActive() {
-    return this.refs[this.active.collection].find(
+    const ref = this.refs[this.active.collection];
+
+    for (let i = 0; i < ref.length; i++) {
+      const { node } = ref[i];
+
       // eslint-disable-next-line eqeqeq
-      ({node}) => node.sortableInfo.index == this.active.index,
-    );
+      if (node.sortableInfo.index == this.active.index) {
+        return ref[i];
+      }
+    }
   }
 
   getIndex(collection, ref) {

--- a/src/Manager/index.js
+++ b/src/Manager/index.js
@@ -32,7 +32,7 @@ export default class Manager {
         return nodes[i];
       }
     }
-    
+
     return undefined;
   }
 

--- a/src/Manager/index.js
+++ b/src/Manager/index.js
@@ -22,16 +22,18 @@ export default class Manager {
   }
 
   getActive() {
-    const ref = this.refs[this.active.collection];
+    const nodes = this.refs[this.active.collection];
 
-    for (let i = 0; i < ref.length; i++) {
-      const { node } = ref[i];
+    for (let i = 0, len = nodes.length; i < len; i++) {
+      const {node} = nodes[i];
 
       // eslint-disable-next-line eqeqeq
       if (node.sortableInfo.index == this.active.index) {
-        return ref[i];
+        return nodes[i];
       }
     }
+    
+    return undefined;
   }
 
   getIndex(collection, ref) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -225,9 +225,9 @@ function isScrollable(el) {
   const overflowRegex = /(auto|scroll)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 
-  return properties.find((property) =>
+  return properties.filter((property) =>
     overflowRegex.test(computedStyle[property]),
-  );
+  ).length > 0;
 }
 
 export function getScrollingParent(el) {


### PR DESCRIPTION
Fixes #525

`Array.find()` doesn't work in [IE11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) at all. 

So, this is super light-weight fix which allows supporting IE9+ browsers.