### PR TITLE
Use vanilla loop to get rid of Symbol.iterator and Array.from dependencies

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -254,9 +254,11 @@ export function cloneNode(node) {
   const selector = 'input, textarea, select, canvas, [contenteditable]';
   const fields = node.querySelectorAll(selector);
   const clonedNode = node.cloneNode(true);
-  const clonedFields = [...clonedNode.querySelectorAll(selector)];
+  const clonedFields = clonedNode.querySelectorAll(selector);
 
-  clonedFields.forEach((field, i) => {
+  for (let i = 0; i < clonedFields.length; i++) {
+    const field = clonedFields[i];
+
     if (field.type !== 'file') {
       field.value = fields[i].value;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -273,7 +273,7 @@ export function cloneNode(node) {
       const destCtx = field.getContext('2d');
       destCtx.drawImage(fields[i], 0, 0);
     }
-  });
+  }
 
   return clonedNode;
 }


### PR DESCRIPTION
One more PR to support IE11 and avoid this issue:
![image](https://user-images.githubusercontent.com/1918108/56207830-62a6d500-6058-11e9-9755-d7d74d40bd5b.png)
