### PR TITLE
Don't copy canvas context if canvas has 0 dimension

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -296,7 +296,11 @@ export function cloneNode(node) {
       field.name = `__sortableClone__${field.name}`;
     }
 
-    if (field.tagName === NodeType.Canvas) {
+    if (
+      field.tagName === NodeType.Canvas &&
+      fields[i].width > 0 &&
+      fields[i].height > 0
+    ) {
       const destCtx = field.getContext('2d');
       destCtx.drawImage(fields[i], 0, 0);
     }


### PR DESCRIPTION
This addresses a bug introduced in version 1.8.0 (https://github.com/clauderic/react-sortable-hoc/commit/43ad122) that currently occurs when a canvas element within a cloned node has no width or no height. When this happens, the following exception is thrown:

```
Uncaught (in promise) DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0.
```

To handle this, we simply check the width and height on every canvas element before copying its context over.