### PR TITLE
Fix #440 by listening to event target on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 100% credit for this project belongs to clauderic and the rest of the [react-sortable-hoc team](http://clauderic.github.io/react-sortable-hoc/). This fork merely solves a simple mobile dragging issue described and solved [here](https://gist.github.com/parris/dda613e3ae78f14eb2dc9fa0f4bfce3d).
 If and when [my pull request](https://github.com/clauderic/react-sortable-hoc/pull/532) is merged, I'll be happy to pull this down. I will keep this package in sync with the original as often as I can.
 
+[npm package with fix(es) applied](https://www.npmjs.com/package/react-sortable-hoc-fixed)
+
 ----------------------------
 
 # <img src="https://user-images.githubusercontent.com/1416436/54170652-dfd59d80-444d-11e9-9c51-658638c0454b.png" width="400" alt="React Sortable HOC" />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+100% credit for this project belongs to clauderic and the rest of the [react-sortable-hoc team](http://clauderic.github.io/react-sortable-hoc/). This fork merely solves a simple mobile dragging issue described and solved [here](https://gist.github.com/parris/dda613e3ae78f14eb2dc9fa0f4bfce3d).
+If and when [my pull request](https://github.com/clauderic/react-sortable-hoc/pull/532) is merged, I'll be happy to pull this down. I will keep this package in sync with the original as often as I can.
+
+----------------------------
+
 # <img src="https://user-images.githubusercontent.com/1416436/54170652-dfd59d80-444d-11e9-9c51-658638c0454b.png" width="400" alt="React Sortable HOC" />
 
 > A set of higher-order components to turn any list into an animated, accessible and touch-friendly sortable list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc-fixed",
-  "version": "1.9.1",
+  "version": "1.9.1p",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-sortable-hoc",
+  "name": "react-sortable-hoc-fixed",
   "version": "1.9.1",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",
     "email": "me@ced.io"
   },
-  "user": "clauderic",
+  "user": "davidchappy",
   "homepage": "https://github.com/clauderic/react-sortable-hoc",
   "source": "src/index.js",
   "main": "dist/react-sortable-hoc.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc-fixed",
-  "version": "1.9.1-p",
+  "version": "1.9.1-p2",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc-fixed",
-  "version": "1.9.1p",
+  "version": "1.9.1-p",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/clauderic/react-sortable-hoc.git"
+    "url": "https://github.com/davidchappy/react-sortable-hoc.git"
   },
   "bugs": {
     "url": "https://github.com/clauderic/react-sortable-hoc/issues"

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -332,11 +332,11 @@ export default function sortableContainer(
             height: containerHeight,
           } = useWindowAsScrollContainer
             ? {
-              top: 0,
-              left: 0,
-              width: this.contentWindow.innerWidth,
-              height: this.contentWindow.innerHeight,
-            }
+                top: 0,
+                left: 0,
+                width: this.contentWindow.innerWidth,
+                height: this.contentWindow.innerHeight,
+              }
             : this.containerBoundingRect;
           const containerBottom = containerTop + containerHeight;
           const containerRight = containerLeft + containerWidth;
@@ -386,7 +386,8 @@ export default function sortableContainer(
             .forEach((className) => this.helper.classList.add(className));
         }
 
-        this.listenerNode = event.touches ? node : this.contentWindow;
+        // this.listenerNode = event.touches ? node : this.contentWindow;
+        this.listenerNode = event.touches ? event.target : this.contentWindow;
 
         if (isKeySorting) {
           this.listenerNode.addEventListener('wheel', this.handleKeyEnd, true);


### PR DESCRIPTION
I believe this addresses #440 and #9. 

The underlying issue with dragging on mobile seems to be related to [this issue](https://github.com/facebook/react/issues/13113). This pull request implements [this proposed solution](https://gist.github.com/parris/dda613e3ae78f14eb2dc9fa0f4bfce3d), by simply listening to event.target if the event is a mobile event (ie `event.touches`). 

This works in my tests, but obviously open to discussion.