### PR TITLE
The helperContainer callback should provide the this context

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -1036,10 +1036,10 @@ export default function sortableContainer(
       const {helperContainer} = this.props;
 
       if (typeof helperContainer === 'function') {
-        return helperContainer();
+        return helperContainer.call(this);
       }
 
-      return this.props.helperContainer || this.document.body;
+      return this.props.helperContainer || this.document.body; //Why body and not this.container by default?
     }
 
     get containerScrollDelta() {


### PR DESCRIPTION
If I want to append the sorted element within the element that is being sorted (to not lose styling because there is a lot of css rules)
I need to pass helperContainer: () => { return this.container } as a prop, but the this is not passed as a context to the function so it doesn't work, adding .call(this) effectively addresses the issue

I was also wondering why append the element to the body and not to the container by default? It would prevent a lot of issues