### PR TITLE
Disable sorting on middle mouse button

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -120,7 +120,7 @@ export default function sortableContainer(
     handleStart = (event) => {
       const {distance, shouldCancelStart} = this.props;
 
-      if (event.button === 2 || shouldCancelStart(event)) {
+      if (event.button !== 0 || shouldCancelStart(event)) {
         return;
       }
 


### PR DESCRIPTION
Right now sorting can be started by either the main (left) or middle (wheel) button. The latter doesn't really make sense, especially as it conflicts with the middle click scroll functionality.

This could potentially be a breaking change, though I doubt anyone relies on it. As least no one should :)