### PR TITLE
Remove browser field with umd bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "source": "src/index.js",
   "main": "dist/react-sortable-hoc.js",
   "umd:main": "dist/react-sortable-hoc.umd.js",
-  "browser": "dist/react-sortable-hoc.umd.js",
   "module": "dist/react-sortable-hoc.esm.js",
   "jsnext:main": "dist/react-sortable-hoc.esm.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
`browser` field has a priority over `module` field in all bundlers. Adding it to package.json drops all goodness of esm bundle.
It should be used in a bit different way to support both node and browser fields.
https://github.com/uber/react-map-gl/blob/1da1398c063ffc3b8464744bde6781cb5dc3866e/package.json#L20-L24