### PR TITLE
Added onShouldSortOver

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -538,6 +538,21 @@ storiesOf('General | Configuration / Options', module)
       </div>
     );
   })
+  .add('onShouldSortOver (only odd indices)', () => {
+    return (
+      <div className={style.root}>
+        <ListWrapper
+          component={SortableList}
+          items={getItems(50, 59)}
+          helperClass={style.stylizedHelper}
+          onShouldSortOver={({index, newIndex}) => {
+            console.log('new index', index, newIndex);
+            return (newIndex & 1) === 0;
+          }}
+        />
+      </div>
+    );
+  })
   .add('Disabled items', () => {
     return (
       <div className={style.root}>

--- a/src/SortableContainer/props.js
+++ b/src/SortableContainer/props.js
@@ -31,6 +31,7 @@ export const propTypes = {
   lockToContainerEdges: PropTypes.bool,
   onSortEnd: PropTypes.func,
   onSortMove: PropTypes.func,
+  onShouldSortOver: PropTypes.func,
   onSortOver: PropTypes.func,
   onSortStart: PropTypes.func,
   pressDelay: PropTypes.number,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,6 +68,7 @@ export interface SortableContainerProps {
   onSortMove?: SortMoveHandler;
   onSortEnd?: SortEndHandler;
   onSortOver?: SortOverHandler;
+  onShouldSortOver?: SortOverHandler;
   useDragHandle?: boolean;
   useWindowAsScrollContainer?: boolean;
   hideSortableGhost?: boolean;


### PR DESCRIPTION
A simple callback that is invoked before the item is sorted. It has the same arguments as the `onSortOver` callback.

Return `true` if the helper can be dragged into the new position.