### PR TITLE
fix: type mistake of shouldCancelStart

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,7 +62,7 @@ export interface SortableContainerProps {
   pressDelay?: number;
   pressThreshold?: number;
   distance?: number;
-  shouldCancelStart?: (event: SortEvent | SortEventWithTag) => boolean;
+  shouldCancelStart?: ((event: SortEvent) => boolean) | ((event: SortEventWithTag) => boolean);
   updateBeforeSortStart?: SortStartHandler;
   onSortStart?: SortStartHandler;
   onSortMove?: SortMoveHandler;


### PR DESCRIPTION
A type error occurred when writing this code.

```
const func = (e: SortEventWithTag) => true  //  (e: SortEventWithTag) => boolean

const Component: React.FC = () => (
  <SortableList
    ....
    shouldCancelStart={func}   // type error
  />
)
```

I think type of shouldCancelStart should be 
`((e: SortEvent) => boolean) | ((e: SortEventWithTag) => boolean)` .