### PR TITLE
Case update for `react-sortable-hoc` exports

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,9 +1,9 @@
 import React, {Component} from 'react';
 import {render} from 'react-dom';
-import {sortableContainer, sortableElement} from 'react-sortable-hoc';
+import {SortableContainer as sortableContainer, SortableElement} from 'react-sortable-hoc';
 import arrayMove from 'array-move';
 
-const SortableItem = sortableElement(({value}) => <li>{value}</li>);
+const SortableItem = SortableElement(({value}) => <li>{value}</li>);
 
 const SortableContainer = sortableContainer(({children}) => {
   return <ul>{children}</ul>;


### PR DESCRIPTION
The exports at this point are in PascalCase now as is the standard for Classes.

https://www.quora.com/What-is-the-difference-between-Pascal-Case-and-Camel-Case