### PR TITLE
Fix touch events being lost by listening to event.target on mobile

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -387,7 +387,7 @@ export default function sortableContainer(
             .forEach((className) => this.helper.classList.add(className));
         }
 
-        this.listenerNode = event.touches ? node : this.contentWindow;
+        this.listenerNode = event.touches ? event.target : this.contentWindow;
 
         if (isKeySorting) {
           this.listenerNode.addEventListener('wheel', this.handleKeyEnd, true);


### PR DESCRIPTION
This PR is based off of https://github.com/clauderic/react-sortable-hoc/pull/532. Resolves #578, #440 and #9.

> I believe this addresses #440 and #9.
>
> The underlying issue with dragging on mobile seems to be related to this issue. This pull request implements this proposed solution, by simply listening to event.target if the event is a mobile event (ie event.touches).
>
> This works in my tests, but obviously open to discussion.