### PR TITLE
fix: Fix broken UMD build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ const umdConfig = ({minify} = {}) => ({
   external: ['react', 'react-dom', 'prop-types'],
   output: {
     name: 'SortableHOC',
-    file: minify ? pkg.browser.replace('.js', '.min.js') : pkg.browser,
+    file: minify ? pkg["umd:main"].replace('.js', '.min.js') : pkg["umd:main"],
     format: 'umd',
     globals: {
       react: 'React',
@@ -59,7 +59,7 @@ const umdConfig = ({minify} = {}) => ({
       ),
     }),
     commonjs(),
-    minify && uglify(),
+    minify ? uglify() : { },
     filesize(),
   ],
 });


### PR DESCRIPTION
`npm run build` is currently broken, for two reasons:

* `browser` was removed from package.json recently (https://github.com/clauderic/react-sortable-hoc/commit/d3b30fd369a05c732200203d8b421758b6e12222), but it's used in rollup.config.js
* `minify && uglify` becomes `undefined` for the non-minified build, which makes `rollup-plugin-commonjs` throw this (at https://github.com/rollup/rollup-plugin-commonjs/blob/v9.3.4/src/resolve-id.js#L50), because `undefined` isn't a valid plugin:

  ```
  [!] TypeError: Cannot read property 'resolveId' of undefined
  TypeError: Cannot read property 'resolveId' of undefined
      at .../react-sortable-hoc/node_modules/rollup-plugin-commonjs/src/resolve-id.js:52:6
  ```

  (No idea why this wasn't always happening in the past :man_shrugging:)

This PR is a quick fix for both. `umd:main` has the same value `browser` used to have, so that's easy, and replacing undefined with `{}` makes `plugin.resolveId` undefined, which means the plugin gets dropped by rollup, which is really what we want anyway. With this, the build now passes on my machine with a fresh install.