### PR TITLE
Use new context type to prevent de-opts in React

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o/react-sortable-hoc",
-  "version": "1.10.2",
+  "version": "1.10.4",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-sortable-hoc",
+  "name": "@o/react-sortable-hoc",
   "version": "1.10.1",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o/react-sortable-hoc",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -8,7 +8,7 @@ import {isSortableHandle} from '../SortableHandle';
 
 export const SortableContext = React.createContext({
   manager: {},
-})
+});
 
 import {
   cloneNode,
@@ -876,7 +876,7 @@ export default function sortableContainer(
         'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call',
       );
 
-      return this.refs.wrappedInstance;
+      return this.wrappedInstance.current;
     }
 
     getContainer() {
@@ -1024,14 +1024,16 @@ export default function sortableContainer(
       );
     };
 
+    wrappedInstance = React.createRef();
+
     render() {
-      const ref = config.withRef ? 'wrappedInstance' : null;
+      const ref = config.withRef ? this.wrappedInstance : null;
 
       return (
-        <SortableContext.Provider value={{ manager: this.manager }}>
+        <SortableContext.Provider value={{manager: this.manager}}>
           <WrappedComponent ref={ref} {...omit(this.props, omittedProps)} />
         </SortableContext.Provider>
-      )
+      );
     }
 
     get helperContainer() {

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -6,6 +6,10 @@ import invariant from 'invariant';
 import Manager from '../Manager';
 import {isSortableHandle} from '../SortableHandle';
 
+export const SortableContext = React.createContext({
+  manager: {},
+})
+
 import {
   cloneNode,
   closest,
@@ -59,15 +63,6 @@ export default function sortableContainer(
     static displayName = provideDisplayName('sortableList', WrappedComponent);
     static defaultProps = defaultProps;
     static propTypes = propTypes;
-    static childContextTypes = {
-      manager: PropTypes.object.isRequired,
-    };
-
-    getChildContext() {
-      return {
-        manager: this.manager,
-      };
-    }
 
     componentDidMount() {
       const {useWindowAsScrollContainer} = this.props;
@@ -1032,7 +1027,11 @@ export default function sortableContainer(
     render() {
       const ref = config.withRef ? 'wrappedInstance' : null;
 
-      return <WrappedComponent ref={ref} {...omit(this.props, omittedProps)} />;
+      return (
+        <SortableContext.Provider value={{ manager: this.manager }}>
+          <WrappedComponent ref={ref} {...omit(this.props, omittedProps)} />
+        </SortableContext.Provider>
+      )
     }
 
     get helperContainer() {

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import invariant from 'invariant';
-import { SortableContext } from '../SortableContainer';
+import {SortableContext} from '../SortableContainer';
 
 import {provideDisplayName, omit} from '../utils';
 

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -83,11 +83,13 @@ export default function sortableElement(
         config.withRef,
         'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableElement() call',
       );
-      return this.refs.wrappedInstance;
+      return this.wrappedInstance.current;
     }
 
+    wrappedInstance = React.createRef();
+
     render() {
-      const ref = config.withRef ? 'wrappedInstance' : null;
+      const ref = config.withRef ? this.wrappedInstance : null;
 
       return <WrappedComponent ref={ref} {...omit(this.props, omittedProps)} />;
     }

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -24,7 +24,7 @@ export default function sortableElement(
       WrappedComponent,
     );
 
-    static contextTypes = SortableContext;
+    static contextType = SortableContext;
 
     static propTypes = propTypes;
 

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {findDOMNode} from 'react-dom';
 import invariant from 'invariant';
+import { SortableContext } from '../SortableContainer';
 
 import {provideDisplayName, omit} from '../utils';
 
@@ -23,9 +24,7 @@ export default function sortableElement(
       WrappedComponent,
     );
 
-    static contextTypes = {
-      manager: PropTypes.object.isRequired,
-    };
+    static contextTypes = SortableContext;
 
     static propTypes = propTypes;
 

--- a/src/SortableHandle/index.js
+++ b/src/SortableHandle/index.js
@@ -21,11 +21,13 @@ export default function sortableHandle(
         config.withRef,
         'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableHandle() call',
       );
-      return this.refs.wrappedInstance;
+      return this.wrappedInstance.current;
     }
 
+    wrappedInstance = React.createRef();
+
     render() {
-      const ref = config.withRef ? 'wrappedInstance' : null;
+      const ref = config.withRef ? this.wrappedInstance : null;
 
       return <WrappedComponent ref={ref} {...this.props} />;
     }


### PR DESCRIPTION
Using the new context type should fix performance and be forward-comparable with Concurrent mode.