### PR TITLE
Clear autoscroller when autoscroll is disabled

### DIFF
--- a/src/AutoScroller/index.js
+++ b/src/AutoScroller/index.js
@@ -5,11 +5,10 @@ export default class AutoScroller {
   }
 
   clear() {
-    if (this.interval) {
+    if (this.interval != null) {
       clearInterval(this.interval);
+      this.interval = null;
     }
-
-    this.interval = null;
   }
 
   update({translate, minTranslate, maxTranslate, width, height}) {

--- a/src/AutoScroller/index.js
+++ b/src/AutoScroller/index.js
@@ -5,7 +5,10 @@ export default class AutoScroller {
   }
 
   clear() {
-    clearInterval(this.interval);
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+
     this.interval = null;
   }
 

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -827,6 +827,7 @@ export default function sortableContainer(
       const {isKeySorting} = this.manager;
 
       if (disableAutoscroll) {
+        this.autoScroller.clear();
         return;
       }
 


### PR DESCRIPTION
If `disableAutoscroll` is set to `true` by another event while user is dragging, scroll still continues.

Must also clear `autoScroller` when autoscroll gets disabled.