### PR TITLE
Cancel drag if updateBeforeSortStart resolves to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.12.0"></a>
+# [1.12.0](https://github.com/clauderic/react-sortable-hoc/compare/v1.1.0...v1.12.0) (2019-12-02)
+
+
+### Bug Fixes
+
+* added prop-types to peerDependencies ([0e855c5](https://github.com/clauderic/react-sortable-hoc/commit/0e855c5))
+* clear autoscroller when autoscroll is disabled ([#604](https://github.com/clauderic/react-sortable-hoc/issues/604)) ([3fd83f9](https://github.com/clauderic/react-sortable-hoc/commit/3fd83f9))
+* copy canvas content into cloned node ([43ad122](https://github.com/clauderic/react-sortable-hoc/commit/43ad122))
+* do not copy canvas context if it has neither width nor height ([#530](https://github.com/clauderic/react-sortable-hoc/issues/530)) ([3808437](https://github.com/clauderic/react-sortable-hoc/commit/3808437))
+* don't spread the keysToOmit parameter in omit util ([#563](https://github.com/clauderic/react-sortable-hoc/issues/563)) ([1c69772](https://github.com/clauderic/react-sortable-hoc/commit/1c69772))
+* Fix broken UMD build ([#587](https://github.com/clauderic/react-sortable-hoc/issues/587)) ([6cb7750](https://github.com/clauderic/react-sortable-hoc/commit/6cb7750))
+* get updated index after updateBeforeSortStart ([4471a0a](https://github.com/clauderic/react-sortable-hoc/commit/4471a0a))
+* helperContainer PropType definition broke server-side rendering ([#471](https://github.com/clauderic/react-sortable-hoc/issues/471)) ([c0eef97](https://github.com/clauderic/react-sortable-hoc/commit/c0eef97))
+* invalid helperContainer PropType definition ([#493](https://github.com/clauderic/react-sortable-hoc/issues/493)) ([dc1d18f](https://github.com/clauderic/react-sortable-hoc/commit/dc1d18f))
+* issue with cloning canvas context of dragged items ([#512](https://github.com/clauderic/react-sortable-hoc/issues/512)) ([4df34ad](https://github.com/clauderic/react-sortable-hoc/commit/4df34ad))
+* issue with getComputedStyle and getScrollingParent ([b104249](https://github.com/clauderic/react-sortable-hoc/commit/b104249))
+* issue with radio input name collision when cloning helper ([5337c97](https://github.com/clauderic/react-sortable-hoc/commit/5337c97))
+* issue with windowAsScrollContainer and translation offsets ([0391e62](https://github.com/clauderic/react-sortable-hoc/commit/0391e62))
+* lock axis story should not use lockToContainerEdges ([db1d3a9](https://github.com/clauderic/react-sortable-hoc/commit/db1d3a9))
+* omit disableAutoscroll prop ([#502](https://github.com/clauderic/react-sortable-hoc/issues/502)) ([e994e73](https://github.com/clauderic/react-sortable-hoc/commit/e994e73))
+* omit spreading helperContainer prop ([#497](https://github.com/clauderic/react-sortable-hoc/issues/497)) ([12bafdf](https://github.com/clauderic/react-sortable-hoc/commit/12bafdf))
+* overflow bug while dragging an item upwards in a grid ([1a2c87e](https://github.com/clauderic/react-sortable-hoc/commit/1a2c87e))
+* pass isKeySorting to onSortOver and updateBeforeSortStart handler props ([#531](https://github.com/clauderic/react-sortable-hoc/issues/531)) ([763fd33](https://github.com/clauderic/react-sortable-hoc/commit/763fd33))
+* PropType definition for keyCodes was incorrect ([eaf5070](https://github.com/clauderic/react-sortable-hoc/commit/eaf5070))
+* remove browser field with umd bundle ([#541](https://github.com/clauderic/react-sortable-hoc/issues/541)) ([d3b30fd](https://github.com/clauderic/react-sortable-hoc/commit/d3b30fd))
+* replace process.env.NODE_ENV in UMD builds ([16135df](https://github.com/clauderic/react-sortable-hoc/commit/16135df))
+* update helperContainer prop type definition ([#491](https://github.com/clauderic/react-sortable-hoc/issues/491)) ([fd30383](https://github.com/clauderic/react-sortable-hoc/commit/fd30383))
+* updated the behaviour of disabled elements ([bd3d041](https://github.com/clauderic/react-sortable-hoc/commit/bd3d041))
+* virtualized collection grid bug ([a57975c](https://github.com/clauderic/react-sortable-hoc/commit/a57975c))
+
+
+### Features
+
+* Add disableAutoscroll prop ([#484](https://github.com/clauderic/react-sortable-hoc/issues/484)) ([7845e76](https://github.com/clauderic/react-sortable-hoc/commit/7845e76))
+* Add keyCodes prop to configure the keyboard shortcuts ([#588](https://github.com/clauderic/react-sortable-hoc/issues/588)) ([4c6d8dd](https://github.com/clauderic/react-sortable-hoc/commit/4c6d8dd))
+* add support for keyboard sorting ([#501](https://github.com/clauderic/react-sortable-hoc/issues/501)) ([439b92f](https://github.com/clauderic/react-sortable-hoc/commit/439b92f))
+* added helperContainer prop ([286eff4](https://github.com/clauderic/react-sortable-hoc/commit/286eff4))
+* allow helperContainer prop to be a function returning an HTMLElement ([#489](https://github.com/clauderic/react-sortable-hoc/issues/489)) ([f4a9b4a](https://github.com/clauderic/react-sortable-hoc/commit/f4a9b4a))
+* Detect scroll container automatically ([#507](https://github.com/clauderic/react-sortable-hoc/issues/507)) ([6572921](https://github.com/clauderic/react-sortable-hoc/commit/6572921))
+* prevent sort start on contentEditable target ([d64c8cf](https://github.com/clauderic/react-sortable-hoc/commit/d64c8cf))
+
+
+
 <a name="1.11.0"></a>
 # [1.11.0](https://github.com/clauderic/react-sortable-hoc/compare/v1.1.0...v1.11.0) (2019-12-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.11.0"></a>
+# [1.11.0](https://github.com/clauderic/react-sortable-hoc/compare/v1.1.0...v1.11.0) (2019-12-02)
+
+
+### Bug Fixes
+
+* added prop-types to peerDependencies ([0e855c5](https://github.com/clauderic/react-sortable-hoc/commit/0e855c5))
+* clear autoscroller when autoscroll is disabled ([#604](https://github.com/clauderic/react-sortable-hoc/issues/604)) ([3fd83f9](https://github.com/clauderic/react-sortable-hoc/commit/3fd83f9))
+* copy canvas content into cloned node ([43ad122](https://github.com/clauderic/react-sortable-hoc/commit/43ad122))
+* do not copy canvas context if it has neither width nor height ([#530](https://github.com/clauderic/react-sortable-hoc/issues/530)) ([3808437](https://github.com/clauderic/react-sortable-hoc/commit/3808437))
+* don't spread the keysToOmit parameter in omit util ([#563](https://github.com/clauderic/react-sortable-hoc/issues/563)) ([1c69772](https://github.com/clauderic/react-sortable-hoc/commit/1c69772))
+* Fix broken UMD build ([#587](https://github.com/clauderic/react-sortable-hoc/issues/587)) ([6cb7750](https://github.com/clauderic/react-sortable-hoc/commit/6cb7750))
+* get updated index after updateBeforeSortStart ([4471a0a](https://github.com/clauderic/react-sortable-hoc/commit/4471a0a))
+* helperContainer PropType definition broke server-side rendering ([#471](https://github.com/clauderic/react-sortable-hoc/issues/471)) ([c0eef97](https://github.com/clauderic/react-sortable-hoc/commit/c0eef97))
+* invalid helperContainer PropType definition ([#493](https://github.com/clauderic/react-sortable-hoc/issues/493)) ([dc1d18f](https://github.com/clauderic/react-sortable-hoc/commit/dc1d18f))
+* issue with cloning canvas context of dragged items ([#512](https://github.com/clauderic/react-sortable-hoc/issues/512)) ([4df34ad](https://github.com/clauderic/react-sortable-hoc/commit/4df34ad))
+* issue with getComputedStyle and getScrollingParent ([b104249](https://github.com/clauderic/react-sortable-hoc/commit/b104249))
+* issue with radio input name collision when cloning helper ([5337c97](https://github.com/clauderic/react-sortable-hoc/commit/5337c97))
+* issue with windowAsScrollContainer and translation offsets ([0391e62](https://github.com/clauderic/react-sortable-hoc/commit/0391e62))
+* lock axis story should not use lockToContainerEdges ([db1d3a9](https://github.com/clauderic/react-sortable-hoc/commit/db1d3a9))
+* omit disableAutoscroll prop ([#502](https://github.com/clauderic/react-sortable-hoc/issues/502)) ([e994e73](https://github.com/clauderic/react-sortable-hoc/commit/e994e73))
+* omit spreading helperContainer prop ([#497](https://github.com/clauderic/react-sortable-hoc/issues/497)) ([12bafdf](https://github.com/clauderic/react-sortable-hoc/commit/12bafdf))
+* overflow bug while dragging an item upwards in a grid ([1a2c87e](https://github.com/clauderic/react-sortable-hoc/commit/1a2c87e))
+* pass isKeySorting to onSortOver and updateBeforeSortStart handler props ([#531](https://github.com/clauderic/react-sortable-hoc/issues/531)) ([763fd33](https://github.com/clauderic/react-sortable-hoc/commit/763fd33))
+* PropType definition for keyCodes was incorrect ([eaf5070](https://github.com/clauderic/react-sortable-hoc/commit/eaf5070))
+* remove browser field with umd bundle ([#541](https://github.com/clauderic/react-sortable-hoc/issues/541)) ([d3b30fd](https://github.com/clauderic/react-sortable-hoc/commit/d3b30fd))
+* replace process.env.NODE_ENV in UMD builds ([16135df](https://github.com/clauderic/react-sortable-hoc/commit/16135df))
+* update helperContainer prop type definition ([#491](https://github.com/clauderic/react-sortable-hoc/issues/491)) ([fd30383](https://github.com/clauderic/react-sortable-hoc/commit/fd30383))
+* updated the behaviour of disabled elements ([bd3d041](https://github.com/clauderic/react-sortable-hoc/commit/bd3d041))
+* virtualized collection grid bug ([a57975c](https://github.com/clauderic/react-sortable-hoc/commit/a57975c))
+
+
+### Features
+
+* Add disableAutoscroll prop ([#484](https://github.com/clauderic/react-sortable-hoc/issues/484)) ([7845e76](https://github.com/clauderic/react-sortable-hoc/commit/7845e76))
+* Add keyCodes prop to configure the keyboard shortcuts ([#588](https://github.com/clauderic/react-sortable-hoc/issues/588)) ([4c6d8dd](https://github.com/clauderic/react-sortable-hoc/commit/4c6d8dd))
+* add support for keyboard sorting ([#501](https://github.com/clauderic/react-sortable-hoc/issues/501)) ([439b92f](https://github.com/clauderic/react-sortable-hoc/commit/439b92f))
+* added helperContainer prop ([286eff4](https://github.com/clauderic/react-sortable-hoc/commit/286eff4))
+* allow helperContainer prop to be a function returning an HTMLElement ([#489](https://github.com/clauderic/react-sortable-hoc/issues/489)) ([f4a9b4a](https://github.com/clauderic/react-sortable-hoc/commit/f4a9b4a))
+* Detect scroll container automatically ([#507](https://github.com/clauderic/react-sortable-hoc/issues/507)) ([6572921](https://github.com/clauderic/react-sortable-hoc/commit/6572921))
+* prevent sort start on contentEditable target ([d64c8cf](https://github.com/clauderic/react-sortable-hoc/commit/d64c8cf))
+
+
+
 <a name="1.10.1"></a>
 
 ## [1.10.1](https://github.com/clauderic/react-sortable-hoc/compare/v1.10.0...v1.10.1) (2019-08-22)

--- a/dist/react-sortable-hoc.esm.js
+++ b/dist/react-sortable-hoc.esm.js
@@ -1,0 +1,2106 @@
+import _extends from '@babel/runtime/helpers/esm/extends';
+import _slicedToArray from '@babel/runtime/helpers/esm/slicedToArray';
+import _objectSpread from '@babel/runtime/helpers/esm/objectSpread';
+import _classCallCheck from '@babel/runtime/helpers/esm/classCallCheck';
+import _createClass from '@babel/runtime/helpers/esm/createClass';
+import _possibleConstructorReturn from '@babel/runtime/helpers/esm/possibleConstructorReturn';
+import _getPrototypeOf from '@babel/runtime/helpers/esm/getPrototypeOf';
+import _inherits from '@babel/runtime/helpers/esm/inherits';
+import _assertThisInitialized from '@babel/runtime/helpers/esm/assertThisInitialized';
+import _defineProperty from '@babel/runtime/helpers/esm/defineProperty';
+import {createElement, Component} from 'react';
+import PropTypes from 'prop-types';
+import {findDOMNode} from 'react-dom';
+import invariant from 'invariant';
+import _toConsumableArray from '@babel/runtime/helpers/esm/toConsumableArray';
+
+var Manager = (function() {
+  function Manager() {
+    _classCallCheck(this, Manager);
+
+    _defineProperty(this, 'refs', {});
+  }
+
+  _createClass(Manager, [
+    {
+      key: 'add',
+      value: function add(collection, ref) {
+        if (!this.refs[collection]) {
+          this.refs[collection] = [];
+        }
+
+        this.refs[collection].push(ref);
+      },
+    },
+    {
+      key: 'remove',
+      value: function remove(collection, ref) {
+        var index = this.getIndex(collection, ref);
+
+        if (index !== -1) {
+          this.refs[collection].splice(index, 1);
+        }
+      },
+    },
+    {
+      key: 'isActive',
+      value: function isActive() {
+        return this.active;
+      },
+    },
+    {
+      key: 'getActive',
+      value: function getActive() {
+        var _this = this;
+
+        return this.refs[this.active.collection].find(function(_ref) {
+          var node = _ref.node;
+          return node.sortableInfo.index == _this.active.index;
+        });
+      },
+    },
+    {
+      key: 'getIndex',
+      value: function getIndex(collection, ref) {
+        return this.refs[collection].indexOf(ref);
+      },
+    },
+    {
+      key: 'getOrderedRefs',
+      value: function getOrderedRefs() {
+        var collection =
+          arguments.length > 0 && arguments[0] !== undefined
+            ? arguments[0]
+            : this.active.collection;
+        return this.refs[collection].sort(sortByIndex);
+      },
+    },
+  ]);
+
+  return Manager;
+})();
+
+function sortByIndex(_ref2, _ref3) {
+  var index1 = _ref2.node.sortableInfo.index;
+  var index2 = _ref3.node.sortableInfo.index;
+  return index1 - index2;
+}
+
+function arrayMove(array, from, to) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof console !== 'undefined') {
+      console.warn(
+        "Deprecation warning: arrayMove will no longer be exported by 'react-sortable-hoc' in the next major release. Please install the `array-move` package locally instead. https://www.npmjs.com/package/array-move",
+      );
+    }
+  }
+
+  array = array.slice();
+  array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0]);
+  return array;
+}
+function omit(obj, keysToOmit) {
+  return Object.keys(obj).reduce(function(acc, key) {
+    if (keysToOmit.indexOf(key) === -1) {
+      acc[key] = obj[key];
+    }
+
+    return acc;
+  }, {});
+}
+var events = {
+  end: ['touchend', 'touchcancel', 'mouseup'],
+  move: ['touchmove', 'mousemove'],
+  start: ['touchstart', 'mousedown'],
+};
+var vendorPrefix = (function() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return '';
+  }
+
+  var styles = window.getComputedStyle(document.documentElement, '') || [
+    '-moz-hidden-iframe',
+  ];
+  var pre = (Array.prototype.slice
+    .call(styles)
+    .join('')
+    .match(/-(moz|webkit|ms)-/) ||
+    (styles.OLink === '' && ['', 'o']))[1];
+
+  switch (pre) {
+    case 'ms':
+      return 'ms';
+
+    default:
+      return pre && pre.length ? pre[0].toUpperCase() + pre.substr(1) : '';
+  }
+})();
+function setInlineStyles(node, styles) {
+  Object.keys(styles).forEach(function(key) {
+    node.style[key] = styles[key];
+  });
+}
+function setTranslate3d(node, translate) {
+  node.style[''.concat(vendorPrefix, 'Transform')] =
+    translate == null
+      ? ''
+      : 'translate3d('.concat(translate.x, 'px,').concat(translate.y, 'px,0)');
+}
+function setTransitionDuration(node, duration) {
+  node.style[''.concat(vendorPrefix, 'TransitionDuration')] =
+    duration == null ? '' : ''.concat(duration, 'ms');
+}
+function closest(el, fn) {
+  while (el) {
+    if (fn(el)) {
+      return el;
+    }
+
+    el = el.parentNode;
+  }
+
+  return null;
+}
+function limit(min, max, value) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function getPixelValue(stringValue) {
+  if (stringValue.substr(-2) === 'px') {
+    return parseFloat(stringValue);
+  }
+
+  return 0;
+}
+
+function getElementMargin(element) {
+  var style = window.getComputedStyle(element);
+  return {
+    bottom: getPixelValue(style.marginBottom),
+    left: getPixelValue(style.marginLeft),
+    right: getPixelValue(style.marginRight),
+    top: getPixelValue(style.marginTop),
+  };
+}
+function provideDisplayName(prefix, Component$$1) {
+  var componentName = Component$$1.displayName || Component$$1.name;
+  return componentName
+    ? ''.concat(prefix, '(').concat(componentName, ')')
+    : prefix;
+}
+function getScrollAdjustedBoundingClientRect(node, scrollDelta) {
+  var boundingClientRect = node.getBoundingClientRect();
+  return {
+    top: boundingClientRect.top + scrollDelta.top,
+    left: boundingClientRect.left + scrollDelta.left,
+  };
+}
+function getPosition(event) {
+  if (event.touches && event.touches.length) {
+    return {
+      x: event.touches[0].pageX,
+      y: event.touches[0].pageY,
+    };
+  } else if (event.changedTouches && event.changedTouches.length) {
+    return {
+      x: event.changedTouches[0].pageX,
+      y: event.changedTouches[0].pageY,
+    };
+  } else {
+    return {
+      x: event.pageX,
+      y: event.pageY,
+    };
+  }
+}
+function isTouchEvent(event) {
+  return (
+    (event.touches && event.touches.length) ||
+    (event.changedTouches && event.changedTouches.length)
+  );
+}
+function getEdgeOffset(node, parent) {
+  var offset =
+    arguments.length > 2 && arguments[2] !== undefined
+      ? arguments[2]
+      : {
+          left: 0,
+          top: 0,
+        };
+
+  if (!node) {
+    return undefined;
+  }
+
+  var nodeOffset = {
+    left: offset.left + node.offsetLeft,
+    top: offset.top + node.offsetTop,
+  };
+
+  if (node.parentNode === parent) {
+    return nodeOffset;
+  }
+
+  return getEdgeOffset(node.parentNode, parent, nodeOffset);
+}
+function getTargetIndex(newIndex, prevIndex, oldIndex) {
+  if (newIndex < oldIndex && newIndex > prevIndex) {
+    return newIndex - 1;
+  } else if (newIndex > oldIndex && newIndex < prevIndex) {
+    return newIndex + 1;
+  } else {
+    return newIndex;
+  }
+}
+function getLockPixelOffset(_ref) {
+  var lockOffset = _ref.lockOffset,
+    width = _ref.width,
+    height = _ref.height;
+  var offsetX = lockOffset;
+  var offsetY = lockOffset;
+  var unit = 'px';
+
+  if (typeof lockOffset === 'string') {
+    var match = /^[+-]?\d*(?:\.\d*)?(px|%)$/.exec(lockOffset);
+    invariant(
+      match !== null,
+      'lockOffset value should be a number or a string of a ' +
+        'number followed by "px" or "%". Given %s',
+      lockOffset,
+    );
+    offsetX = parseFloat(lockOffset);
+    offsetY = parseFloat(lockOffset);
+    unit = match[1];
+  }
+
+  invariant(
+    isFinite(offsetX) && isFinite(offsetY),
+    'lockOffset value should be a finite. Given %s',
+    lockOffset,
+  );
+
+  if (unit === '%') {
+    offsetX = (offsetX * width) / 100;
+    offsetY = (offsetY * height) / 100;
+  }
+
+  return {
+    x: offsetX,
+    y: offsetY,
+  };
+}
+function getLockPixelOffsets(_ref2) {
+  var height = _ref2.height,
+    width = _ref2.width,
+    lockOffset = _ref2.lockOffset;
+  var offsets = Array.isArray(lockOffset)
+    ? lockOffset
+    : [lockOffset, lockOffset];
+  invariant(
+    offsets.length === 2,
+    'lockOffset prop of SortableContainer should be a single ' +
+      'value or an array of exactly two values. Given %s',
+    lockOffset,
+  );
+
+  var _offsets = _slicedToArray(offsets, 2),
+    minLockOffset = _offsets[0],
+    maxLockOffset = _offsets[1];
+
+  return [
+    getLockPixelOffset({
+      height: height,
+      lockOffset: minLockOffset,
+      width: width,
+    }),
+    getLockPixelOffset({
+      height: height,
+      lockOffset: maxLockOffset,
+      width: width,
+    }),
+  ];
+}
+
+function isScrollable(el) {
+  var computedStyle = window.getComputedStyle(el);
+  var overflowRegex = /(auto|scroll)/;
+  var properties = ['overflow', 'overflowX', 'overflowY'];
+  return properties.find(function(property) {
+    return overflowRegex.test(computedStyle[property]);
+  });
+}
+
+function getScrollingParent(el) {
+  if (!(el instanceof HTMLElement)) {
+    return null;
+  } else if (isScrollable(el)) {
+    return el;
+  } else {
+    return getScrollingParent(el.parentNode);
+  }
+}
+var KEYCODE = {
+  TAB: 9,
+  ESC: 27,
+  SPACE: 32,
+  LEFT: 37,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
+};
+var NodeType = {
+  Anchor: 'A',
+  Button: 'BUTTON',
+  Canvas: 'CANVAS',
+  Input: 'INPUT',
+  Option: 'OPTION',
+  Textarea: 'TEXTAREA',
+  Select: 'SELECT',
+};
+function cloneNode(node) {
+  var selector = 'input, textarea, select, canvas, [contenteditable]';
+  var fields = node.querySelectorAll(selector);
+  var clonedNode = node.cloneNode(true);
+
+  var clonedFields = _toConsumableArray(clonedNode.querySelectorAll(selector));
+
+  clonedFields.forEach(function(field, i) {
+    if (field.type !== 'file') {
+      field.value = fields[i].value;
+    }
+
+    if (field.type === 'radio' && field.name) {
+      field.name = '__sortableClone__'.concat(field.name);
+    }
+
+    if (
+      field.tagName === NodeType.Canvas &&
+      fields[i].width > 0 &&
+      fields[i].height > 0
+    ) {
+      var destCtx = field.getContext('2d');
+      destCtx.drawImage(fields[i], 0, 0);
+    }
+  });
+  return clonedNode;
+}
+
+function sortableHandle(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableHandle, _React$Component);
+
+      function WithSortableHandle() {
+        _classCallCheck(this, WithSortableHandle);
+
+        return _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableHandle).apply(this, arguments),
+        );
+      }
+
+      _createClass(WithSortableHandle, [
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            var node = findDOMNode(this);
+            node.sortableHandle = true;
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableHandle() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                this.props,
+              ),
+            );
+          },
+        },
+      ]);
+
+      return WithSortableHandle;
+    })(Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableHandle', WrappedComponent),
+    ),
+    _temp
+  );
+}
+function isSortableHandle(node) {
+  return node.sortableHandle != null;
+}
+
+var AutoScroller = (function() {
+  function AutoScroller(container, onScrollCallback) {
+    _classCallCheck(this, AutoScroller);
+
+    this.container = container;
+    this.onScrollCallback = onScrollCallback;
+  }
+
+  _createClass(AutoScroller, [
+    {
+      key: 'clear',
+      value: function clear() {
+        if (this.interval == null) {
+          return;
+        }
+
+        clearInterval(this.interval);
+        this.interval = null;
+      },
+    },
+    {
+      key: 'update',
+      value: function update(_ref) {
+        var _this = this;
+
+        var translate = _ref.translate,
+          minTranslate = _ref.minTranslate,
+          maxTranslate = _ref.maxTranslate,
+          width = _ref.width,
+          height = _ref.height;
+        var direction = {
+          x: 0,
+          y: 0,
+        };
+        var speed = {
+          x: 1,
+          y: 1,
+        };
+        var acceleration = {
+          x: 10,
+          y: 10,
+        };
+        var _this$container = this.container,
+          scrollTop = _this$container.scrollTop,
+          scrollLeft = _this$container.scrollLeft,
+          scrollHeight = _this$container.scrollHeight,
+          scrollWidth = _this$container.scrollWidth,
+          clientHeight = _this$container.clientHeight,
+          clientWidth = _this$container.clientWidth;
+        var isTop = scrollTop === 0;
+        var isBottom = scrollHeight - scrollTop - clientHeight === 0;
+        var isLeft = scrollLeft === 0;
+        var isRight = scrollWidth - scrollLeft - clientWidth === 0;
+
+        if (translate.y >= maxTranslate.y - height / 2 && !isBottom) {
+          direction.y = 1;
+          speed.y =
+            acceleration.y *
+            Math.abs((maxTranslate.y - height / 2 - translate.y) / height);
+        } else if (translate.x >= maxTranslate.x - width / 2 && !isRight) {
+          direction.x = 1;
+          speed.x =
+            acceleration.x *
+            Math.abs((maxTranslate.x - width / 2 - translate.x) / width);
+        } else if (translate.y <= minTranslate.y + height / 2 && !isTop) {
+          direction.y = -1;
+          speed.y =
+            acceleration.y *
+            Math.abs((translate.y - height / 2 - minTranslate.y) / height);
+        } else if (translate.x <= minTranslate.x + width / 2 && !isLeft) {
+          direction.x = -1;
+          speed.x =
+            acceleration.x *
+            Math.abs((translate.x - width / 2 - minTranslate.x) / width);
+        }
+
+        if (this.interval) {
+          this.clear();
+          this.isAutoScrolling = false;
+        }
+
+        if (direction.x !== 0 || direction.y !== 0) {
+          this.interval = setInterval(function() {
+            _this.isAutoScrolling = true;
+            var offset = {
+              left: speed.x * direction.x,
+              top: speed.y * direction.y,
+            };
+            _this.container.scrollTop += offset.top;
+            _this.container.scrollLeft += offset.left;
+
+            _this.onScrollCallback(offset);
+          }, 5);
+        }
+      },
+    },
+  ]);
+
+  return AutoScroller;
+})();
+
+function defaultGetHelperDimensions(_ref) {
+  var node = _ref.node;
+  return {
+    height: node.offsetHeight,
+    width: node.offsetWidth,
+  };
+}
+
+function defaultShouldCancelStart(event) {
+  var interactiveElements = [
+    NodeType.Input,
+    NodeType.Textarea,
+    NodeType.Select,
+    NodeType.Option,
+    NodeType.Button,
+  ];
+
+  if (interactiveElements.indexOf(event.target.tagName) !== -1) {
+    return true;
+  }
+
+  if (
+    closest(event.target, function(el) {
+      return el.contentEditable === 'true';
+    })
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+var propTypes = {
+  axis: PropTypes.oneOf(['x', 'y', 'xy']),
+  contentWindow: PropTypes.any,
+  disableAutoscroll: PropTypes.bool,
+  distance: PropTypes.number,
+  getContainer: PropTypes.func,
+  getHelperDimensions: PropTypes.func,
+  helperClass: PropTypes.string,
+  helperContainer: PropTypes.oneOfType([
+    PropTypes.func,
+    typeof HTMLElement === 'undefined'
+      ? PropTypes.any
+      : PropTypes.instanceOf(HTMLElement),
+  ]),
+  hideSortableGhost: PropTypes.bool,
+  keyboardSortingTransitionDuration: PropTypes.number,
+  lockAxis: PropTypes.string,
+  lockOffset: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    ),
+  ]),
+  lockToContainerEdges: PropTypes.bool,
+  onSortEnd: PropTypes.func,
+  onSortMove: PropTypes.func,
+  onSortOver: PropTypes.func,
+  onSortStart: PropTypes.func,
+  pressDelay: PropTypes.number,
+  pressThreshold: PropTypes.number,
+  keyCodes: PropTypes.shape({
+    lift: PropTypes.arrayOf(PropTypes.number),
+    drop: PropTypes.arrayOf(PropTypes.number),
+    cancel: PropTypes.arrayOf(PropTypes.number),
+    up: PropTypes.arrayOf(PropTypes.number),
+    down: PropTypes.arrayOf(PropTypes.number),
+  }),
+  shouldCancelStart: PropTypes.func,
+  transitionDuration: PropTypes.number,
+  updateBeforeSortStart: PropTypes.func,
+  useDragHandle: PropTypes.bool,
+  useWindowAsScrollContainer: PropTypes.bool,
+};
+var defaultKeyCodes = {
+  lift: [KEYCODE.SPACE],
+  drop: [KEYCODE.SPACE],
+  cancel: [KEYCODE.ESC],
+  up: [KEYCODE.UP, KEYCODE.LEFT],
+  down: [KEYCODE.DOWN, KEYCODE.RIGHT],
+};
+var defaultProps = {
+  axis: 'y',
+  disableAutoscroll: false,
+  distance: 0,
+  getHelperDimensions: defaultGetHelperDimensions,
+  hideSortableGhost: true,
+  lockOffset: '50%',
+  lockToContainerEdges: false,
+  pressDelay: 0,
+  pressThreshold: 5,
+  keyCodes: defaultKeyCodes,
+  shouldCancelStart: defaultShouldCancelStart,
+  transitionDuration: 300,
+  useWindowAsScrollContainer: false,
+};
+var omittedProps = Object.keys(propTypes);
+function validateProps(props) {
+  invariant(
+    !(props.distance && props.pressDelay),
+    'Attempted to set both `pressDelay` and `distance` on SortableContainer, you may only use one or the other, not both at the same time.',
+  );
+}
+
+function _finallyRethrows(body, finalizer) {
+  try {
+    var result = body();
+  } catch (e) {
+    return finalizer(true, e);
+  }
+
+  if (result && result.then) {
+    return result.then(finalizer.bind(null, false), finalizer.bind(null, true));
+  }
+
+  return finalizer(false, value);
+}
+function sortableContainer(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableContainer, _React$Component);
+
+      function WithSortableContainer(props) {
+        var _this;
+
+        _classCallCheck(this, WithSortableContainer);
+
+        _this = _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableContainer).call(this, props),
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'state',
+          {},
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleStart',
+          function(event) {
+            var _this$props = _this.props,
+              distance = _this$props.distance,
+              shouldCancelStart = _this$props.shouldCancelStart;
+
+            if (event.button === 2 || shouldCancelStart(event)) {
+              return;
+            }
+
+            _this.touched = true;
+            _this.position = getPosition(event);
+            var node = closest(event.target, function(el) {
+              return el.sortableInfo != null;
+            });
+
+            if (
+              node &&
+              node.sortableInfo &&
+              _this.nodeIsChild(node) &&
+              !_this.state.sorting
+            ) {
+              var useDragHandle = _this.props.useDragHandle;
+              var _node$sortableInfo = node.sortableInfo,
+                index = _node$sortableInfo.index,
+                collection = _node$sortableInfo.collection,
+                disabled = _node$sortableInfo.disabled;
+
+              if (disabled) {
+                return;
+              }
+
+              if (useDragHandle && !closest(event.target, isSortableHandle)) {
+                return;
+              }
+
+              _this.manager.active = {
+                collection: collection,
+                index: index,
+              };
+
+              if (
+                !isTouchEvent(event) &&
+                event.target.tagName === NodeType.Anchor
+              ) {
+                event.preventDefault();
+              }
+
+              if (!distance) {
+                if (_this.props.pressDelay === 0) {
+                  _this.handlePress(event);
+                } else {
+                  _this.pressTimer = setTimeout(function() {
+                    return _this.handlePress(event);
+                  }, _this.props.pressDelay);
+                }
+              }
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'nodeIsChild',
+          function(node) {
+            return node.sortableInfo.manager === _this.manager;
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleMove',
+          function(event) {
+            var _this$props2 = _this.props,
+              distance = _this$props2.distance,
+              pressThreshold = _this$props2.pressThreshold;
+
+            if (
+              !_this.state.sorting &&
+              _this.touched &&
+              !_this._awaitingUpdateBeforeSortStart
+            ) {
+              var position = getPosition(event);
+              var delta = {
+                x: _this.position.x - position.x,
+                y: _this.position.y - position.y,
+              };
+              var combinedDelta = Math.abs(delta.x) + Math.abs(delta.y);
+              _this.delta = delta;
+
+              if (
+                !distance &&
+                (!pressThreshold || combinedDelta >= pressThreshold)
+              ) {
+                clearTimeout(_this.cancelTimer);
+                _this.cancelTimer = setTimeout(_this.cancel, 0);
+              } else if (
+                distance &&
+                combinedDelta >= distance &&
+                _this.manager.isActive()
+              ) {
+                _this.handlePress(event);
+              }
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleEnd',
+          function() {
+            _this.touched = false;
+
+            _this.cancel();
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'cancel',
+          function() {
+            var distance = _this.props.distance;
+            var sorting = _this.state.sorting;
+
+            if (!sorting) {
+              if (!distance) {
+                clearTimeout(_this.pressTimer);
+              }
+
+              _this.manager.active = null;
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handlePress',
+          function(event) {
+            try {
+              var _exit2 = false;
+
+              var active = _this.manager.getActive();
+
+              return Promise.resolve(
+                (function() {
+                  if (active) {
+                    var _temp4 = function _temp4(_result2) {
+                      if (_exit2) return _result2;
+                      var index = _node.sortableInfo.index;
+                      var margin = getElementMargin(_node);
+
+                      var containerBoundingRect = _this.scrollContainer.getBoundingClientRect();
+
+                      var dimensions = _getHelperDimensions({
+                        collection: _collection,
+                        index: index,
+                        node: _node,
+                      });
+
+                      _this.node = _node;
+                      _this.margin = margin;
+                      _this.width = dimensions.width;
+                      _this.height = dimensions.height;
+                      _this.marginOffset = {
+                        x: _this.margin.left + _this.margin.right,
+                        y: Math.max(_this.margin.top, _this.margin.bottom),
+                      };
+                      _this.boundingClientRect = _node.getBoundingClientRect();
+                      _this.containerBoundingRect = containerBoundingRect;
+                      _this.index = index;
+                      _this.newIndex = index;
+                      _this.axis = {
+                        x: _axis.indexOf('x') >= 0,
+                        y: _axis.indexOf('y') >= 0,
+                      };
+                      _this.offsetEdge = getEdgeOffset(_node, _this.container);
+
+                      if (_isKeySorting) {
+                        _this.initialOffset = getPosition(
+                          _objectSpread({}, event, {
+                            pageX: _this.boundingClientRect.left,
+                            pageY: _this.boundingClientRect.top,
+                          }),
+                        );
+                      } else {
+                        _this.initialOffset = getPosition(event);
+                      }
+
+                      _this.initialScroll = {
+                        left: _this.scrollContainer.scrollLeft,
+                        top: _this.scrollContainer.scrollTop,
+                      };
+                      _this.initialWindowScroll = {
+                        left: window.pageXOffset,
+                        top: window.pageYOffset,
+                      };
+                      _this.helper = _this.helperContainer.appendChild(
+                        cloneNode(_node),
+                      );
+                      setInlineStyles(_this.helper, {
+                        boxSizing: 'border-box',
+                        height: ''.concat(_this.height, 'px'),
+                        left: ''.concat(
+                          _this.boundingClientRect.left - margin.left,
+                          'px',
+                        ),
+                        pointerEvents: 'none',
+                        position: 'fixed',
+                        top: ''.concat(
+                          _this.boundingClientRect.top - margin.top,
+                          'px',
+                        ),
+                        width: ''.concat(_this.width, 'px'),
+                      });
+
+                      if (_isKeySorting) {
+                        _this.helper.focus();
+                      }
+
+                      if (_hideSortableGhost) {
+                        _this.sortableGhost = _node;
+                        setInlineStyles(_node, {
+                          opacity: 0,
+                          visibility: 'hidden',
+                        });
+                      }
+
+                      _this.minTranslate = {};
+                      _this.maxTranslate = {};
+
+                      if (_isKeySorting) {
+                        var _ref = _useWindowAsScrollContainer
+                            ? {
+                                top: 0,
+                                left: 0,
+                                width: _this.contentWindow.innerWidth,
+                                height: _this.contentWindow.innerHeight,
+                              }
+                            : _this.containerBoundingRect,
+                          containerTop = _ref.top,
+                          containerLeft = _ref.left,
+                          containerWidth = _ref.width,
+                          containerHeight = _ref.height;
+
+                        var containerBottom = containerTop + containerHeight;
+                        var containerRight = containerLeft + containerWidth;
+
+                        if (_this.axis.x) {
+                          _this.minTranslate.x =
+                            containerLeft - _this.boundingClientRect.left;
+                          _this.maxTranslate.x =
+                            containerRight -
+                            (_this.boundingClientRect.left + _this.width);
+                        }
+
+                        if (_this.axis.y) {
+                          _this.minTranslate.y =
+                            containerTop - _this.boundingClientRect.top;
+                          _this.maxTranslate.y =
+                            containerBottom -
+                            (_this.boundingClientRect.top + _this.height);
+                        }
+                      } else {
+                        if (_this.axis.x) {
+                          _this.minTranslate.x =
+                            (_useWindowAsScrollContainer
+                              ? 0
+                              : containerBoundingRect.left) -
+                            _this.boundingClientRect.left -
+                            _this.width / 2;
+                          _this.maxTranslate.x =
+                            (_useWindowAsScrollContainer
+                              ? _this.contentWindow.innerWidth
+                              : containerBoundingRect.left +
+                                containerBoundingRect.width) -
+                            _this.boundingClientRect.left -
+                            _this.width / 2;
+                        }
+
+                        if (_this.axis.y) {
+                          _this.minTranslate.y =
+                            (_useWindowAsScrollContainer
+                              ? 0
+                              : containerBoundingRect.top) -
+                            _this.boundingClientRect.top -
+                            _this.height / 2;
+                          _this.maxTranslate.y =
+                            (_useWindowAsScrollContainer
+                              ? _this.contentWindow.innerHeight
+                              : containerBoundingRect.top +
+                                containerBoundingRect.height) -
+                            _this.boundingClientRect.top -
+                            _this.height / 2;
+                        }
+                      }
+
+                      if (_helperClass) {
+                        _helperClass.split(' ').forEach(function(className) {
+                          return _this.helper.classList.add(className);
+                        });
+                      }
+
+                      _this.listenerNode = event.touches
+                        ? _node
+                        : _this.contentWindow;
+
+                      if (_isKeySorting) {
+                        _this.listenerNode.addEventListener(
+                          'wheel',
+                          _this.handleKeyEnd,
+                          true,
+                        );
+
+                        _this.listenerNode.addEventListener(
+                          'mousedown',
+                          _this.handleKeyEnd,
+                          true,
+                        );
+
+                        _this.listenerNode.addEventListener(
+                          'keydown',
+                          _this.handleKeyDown,
+                        );
+                      } else {
+                        events.move.forEach(function(eventName) {
+                          return _this.listenerNode.addEventListener(
+                            eventName,
+                            _this.handleSortMove,
+                            false,
+                          );
+                        });
+                        events.end.forEach(function(eventName) {
+                          return _this.listenerNode.addEventListener(
+                            eventName,
+                            _this.handleSortEnd,
+                            false,
+                          );
+                        });
+                      }
+
+                      _this.setState({
+                        sorting: true,
+                        sortingIndex: index,
+                      });
+
+                      if (_onSortStart) {
+                        _onSortStart(
+                          {
+                            node: _node,
+                            index: index,
+                            collection: _collection,
+                            isKeySorting: _isKeySorting,
+                          },
+                          event,
+                        );
+                      }
+
+                      if (_isKeySorting) {
+                        _this.keyMove(0);
+                      }
+                    };
+
+                    var _this$props3 = _this.props,
+                      _axis = _this$props3.axis,
+                      _getHelperDimensions = _this$props3.getHelperDimensions,
+                      _helperClass = _this$props3.helperClass,
+                      _hideSortableGhost = _this$props3.hideSortableGhost,
+                      updateBeforeSortStart =
+                        _this$props3.updateBeforeSortStart,
+                      _onSortStart = _this$props3.onSortStart,
+                      _useWindowAsScrollContainer =
+                        _this$props3.useWindowAsScrollContainer;
+                    var _node = active.node,
+                      _collection = active.collection;
+                    var _isKeySorting = _this.manager.isKeySorting;
+
+                    var _temp5 = (function() {
+                      if (typeof updateBeforeSortStart === 'function') {
+                        _this._awaitingUpdateBeforeSortStart = true;
+                        return _finallyRethrows(
+                          function() {
+                            var index = _node.sortableInfo.index;
+                            return Promise.resolve(
+                              updateBeforeSortStart(
+                                {
+                                  collection: _collection,
+                                  index: index,
+                                  node: _node,
+                                  isKeySorting: _isKeySorting,
+                                },
+                                event,
+                              ),
+                            ).then(function(result) {
+                              if (result === false) {
+                                _exit2 = true;
+                              }
+                            });
+                          },
+                          function(_wasThrown, _result) {
+                            _this._awaitingUpdateBeforeSortStart = false;
+                            if (_wasThrown) throw _result;
+                            return _result;
+                          },
+                        );
+                      }
+                    })();
+
+                    return _temp5 && _temp5.then
+                      ? _temp5.then(_temp4)
+                      : _temp4(_temp5);
+                  }
+                })(),
+              );
+            } catch (e) {
+              return Promise.reject(e);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleSortMove',
+          function(event) {
+            var onSortMove = _this.props.onSortMove;
+
+            if (typeof event.preventDefault === 'function') {
+              event.preventDefault();
+            }
+
+            _this.updateHelperPosition(event);
+
+            _this.animateNodes();
+
+            _this.autoscroll();
+
+            if (onSortMove) {
+              onSortMove(event);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleSortEnd',
+          function(event) {
+            var _this$props4 = _this.props,
+              hideSortableGhost = _this$props4.hideSortableGhost,
+              onSortEnd = _this$props4.onSortEnd;
+            var _this$manager = _this.manager,
+              collection = _this$manager.active.collection,
+              isKeySorting = _this$manager.isKeySorting;
+            var nodes = _this.manager.refs[collection];
+
+            if (_this.listenerNode) {
+              if (isKeySorting) {
+                _this.listenerNode.removeEventListener(
+                  'wheel',
+                  _this.handleKeyEnd,
+                  true,
+                );
+
+                _this.listenerNode.removeEventListener(
+                  'mousedown',
+                  _this.handleKeyEnd,
+                  true,
+                );
+
+                _this.listenerNode.removeEventListener(
+                  'keydown',
+                  _this.handleKeyDown,
+                );
+              } else {
+                events.move.forEach(function(eventName) {
+                  return _this.listenerNode.removeEventListener(
+                    eventName,
+                    _this.handleSortMove,
+                  );
+                });
+                events.end.forEach(function(eventName) {
+                  return _this.listenerNode.removeEventListener(
+                    eventName,
+                    _this.handleSortEnd,
+                  );
+                });
+              }
+            }
+
+            _this.helper.parentNode.removeChild(_this.helper);
+
+            if (hideSortableGhost && _this.sortableGhost) {
+              setInlineStyles(_this.sortableGhost, {
+                opacity: '',
+                visibility: '',
+              });
+            }
+
+            for (var i = 0, len = nodes.length; i < len; i++) {
+              var _node2 = nodes[i];
+              var el = _node2.node;
+              _node2.edgeOffset = null;
+              _node2.boundingClientRect = null;
+              setTranslate3d(el, null);
+              setTransitionDuration(el, null);
+              _node2.translate = null;
+            }
+
+            _this.autoScroller.clear();
+
+            _this.manager.active = null;
+            _this.manager.isKeySorting = false;
+
+            _this.setState({
+              sorting: false,
+              sortingIndex: null,
+            });
+
+            if (typeof onSortEnd === 'function') {
+              onSortEnd(
+                {
+                  collection: collection,
+                  newIndex: _this.newIndex,
+                  oldIndex: _this.index,
+                  isKeySorting: isKeySorting,
+                },
+                event,
+              );
+            }
+
+            _this.touched = false;
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'autoscroll',
+          function() {
+            var disableAutoscroll = _this.props.disableAutoscroll;
+            var isKeySorting = _this.manager.isKeySorting;
+
+            if (disableAutoscroll) {
+              _this.autoScroller.clear();
+
+              return;
+            }
+
+            if (isKeySorting) {
+              var translate = _objectSpread({}, _this.translate);
+
+              var scrollX = 0;
+              var scrollY = 0;
+
+              if (_this.axis.x) {
+                translate.x = Math.min(
+                  _this.maxTranslate.x,
+                  Math.max(_this.minTranslate.x, _this.translate.x),
+                );
+                scrollX = _this.translate.x - translate.x;
+              }
+
+              if (_this.axis.y) {
+                translate.y = Math.min(
+                  _this.maxTranslate.y,
+                  Math.max(_this.minTranslate.y, _this.translate.y),
+                );
+                scrollY = _this.translate.y - translate.y;
+              }
+
+              _this.translate = translate;
+              setTranslate3d(_this.helper, _this.translate);
+              _this.scrollContainer.scrollLeft += scrollX;
+              _this.scrollContainer.scrollTop += scrollY;
+              return;
+            }
+
+            _this.autoScroller.update({
+              height: _this.height,
+              maxTranslate: _this.maxTranslate,
+              minTranslate: _this.minTranslate,
+              translate: _this.translate,
+              width: _this.width,
+            });
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'onAutoScroll',
+          function(offset) {
+            _this.translate.x += offset.left;
+            _this.translate.y += offset.top;
+
+            _this.animateNodes();
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleKeyDown',
+          function(event) {
+            var keyCode = event.keyCode;
+            var _this$props5 = _this.props,
+              shouldCancelStart = _this$props5.shouldCancelStart,
+              _this$props5$keyCodes = _this$props5.keyCodes,
+              customKeyCodes =
+                _this$props5$keyCodes === void 0 ? {} : _this$props5$keyCodes;
+
+            var keyCodes = _objectSpread({}, defaultKeyCodes, customKeyCodes);
+
+            if (
+              (_this.manager.active && !_this.manager.isKeySorting) ||
+              (!_this.manager.active &&
+                (!keyCodes.lift.includes(keyCode) ||
+                  shouldCancelStart(event) ||
+                  !_this.isValidSortingTarget(event)))
+            ) {
+              return;
+            }
+
+            event.stopPropagation();
+            event.preventDefault();
+
+            if (keyCodes.lift.includes(keyCode) && !_this.manager.active) {
+              _this.keyLift(event);
+            } else if (
+              keyCodes.drop.includes(keyCode) &&
+              _this.manager.active
+            ) {
+              _this.keyDrop(event);
+            } else if (keyCodes.cancel.includes(keyCode)) {
+              _this.newIndex = _this.manager.active.index;
+
+              _this.keyDrop(event);
+            } else if (keyCodes.up.includes(keyCode)) {
+              _this.keyMove(-1);
+            } else if (keyCodes.down.includes(keyCode)) {
+              _this.keyMove(1);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyLift',
+          function(event) {
+            var target = event.target;
+            var node = closest(target, function(el) {
+              return el.sortableInfo != null;
+            });
+            var _node$sortableInfo2 = node.sortableInfo,
+              index = _node$sortableInfo2.index,
+              collection = _node$sortableInfo2.collection;
+            _this.initialFocusedNode = target;
+            _this.manager.isKeySorting = true;
+            _this.manager.active = {
+              index: index,
+              collection: collection,
+            };
+
+            _this.handlePress(event);
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyMove',
+          function(shift) {
+            var nodes = _this.manager.getOrderedRefs();
+
+            var lastIndex = nodes[nodes.length - 1].node.sortableInfo.index;
+            var newIndex = _this.newIndex + shift;
+            var prevIndex = _this.newIndex;
+
+            if (newIndex < 0 || newIndex > lastIndex) {
+              return;
+            }
+
+            _this.prevIndex = prevIndex;
+            _this.newIndex = newIndex;
+            var targetIndex = getTargetIndex(
+              _this.newIndex,
+              _this.prevIndex,
+              _this.index,
+            );
+            var target = nodes.find(function(_ref2) {
+              var node = _ref2.node;
+              return node.sortableInfo.index === targetIndex;
+            });
+            var targetNode = target.node;
+            var scrollDelta = _this.containerScrollDelta;
+            var targetBoundingClientRect =
+              target.boundingClientRect ||
+              getScrollAdjustedBoundingClientRect(targetNode, scrollDelta);
+            var targetTranslate = target.translate || {
+              x: 0,
+              y: 0,
+            };
+            var targetPosition = {
+              top:
+                targetBoundingClientRect.top +
+                targetTranslate.y -
+                scrollDelta.top,
+              left:
+                targetBoundingClientRect.left +
+                targetTranslate.x -
+                scrollDelta.left,
+            };
+            var shouldAdjustForSize = prevIndex < newIndex;
+            var sizeAdjustment = {
+              x:
+                shouldAdjustForSize && _this.axis.x
+                  ? targetNode.offsetWidth - _this.width
+                  : 0,
+              y:
+                shouldAdjustForSize && _this.axis.y
+                  ? targetNode.offsetHeight - _this.height
+                  : 0,
+            };
+
+            _this.handleSortMove({
+              pageX: targetPosition.left + sizeAdjustment.x,
+              pageY: targetPosition.top + sizeAdjustment.y,
+              ignoreTransition: shift === 0,
+            });
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyDrop',
+          function(event) {
+            _this.handleSortEnd(event);
+
+            if (_this.initialFocusedNode) {
+              _this.initialFocusedNode.focus();
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleKeyEnd',
+          function(event) {
+            if (_this.manager.active) {
+              _this.keyDrop(event);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'isValidSortingTarget',
+          function(event) {
+            var useDragHandle = _this.props.useDragHandle;
+            var target = event.target;
+            var node = closest(target, function(el) {
+              return el.sortableInfo != null;
+            });
+            return (
+              node &&
+              node.sortableInfo &&
+              !node.sortableInfo.disabled &&
+              (useDragHandle ? isSortableHandle(target) : target.sortableInfo)
+            );
+          },
+        );
+
+        validateProps(props);
+        _this.manager = new Manager();
+        _this.events = {
+          end: _this.handleEnd,
+          move: _this.handleMove,
+          start: _this.handleStart,
+        };
+        return _this;
+      }
+
+      _createClass(WithSortableContainer, [
+        {
+          key: 'getChildContext',
+          value: function getChildContext() {
+            return {
+              manager: this.manager,
+            };
+          },
+        },
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            var _this2 = this;
+
+            var useWindowAsScrollContainer = this.props
+              .useWindowAsScrollContainer;
+            var container = this.getContainer();
+            Promise.resolve(container).then(function(containerNode) {
+              _this2.container = containerNode;
+              _this2.document = _this2.container.ownerDocument || document;
+              var contentWindow =
+                _this2.props.contentWindow ||
+                _this2.document.defaultView ||
+                window;
+              _this2.contentWindow =
+                typeof contentWindow === 'function'
+                  ? contentWindow()
+                  : contentWindow;
+              _this2.scrollContainer = useWindowAsScrollContainer
+                ? _this2.document.scrollingElement ||
+                  _this2.document.documentElement
+                : getScrollingParent(_this2.container) || _this2.container;
+              _this2.autoScroller = new AutoScroller(
+                _this2.scrollContainer,
+                _this2.onAutoScroll,
+              );
+              Object.keys(_this2.events).forEach(function(key) {
+                return events[key].forEach(function(eventName) {
+                  return _this2.container.addEventListener(
+                    eventName,
+                    _this2.events[key],
+                    false,
+                  );
+                });
+              });
+
+              _this2.container.addEventListener(
+                'keydown',
+                _this2.handleKeyDown,
+              );
+            });
+          },
+        },
+        {
+          key: 'componentWillUnmount',
+          value: function componentWillUnmount() {
+            var _this3 = this;
+
+            if (this.helper && this.helper.parentNode) {
+              this.helper.parentNode.removeChild(this.helper);
+            }
+
+            if (!this.container) {
+              return;
+            }
+
+            Object.keys(this.events).forEach(function(key) {
+              return events[key].forEach(function(eventName) {
+                return _this3.container.removeEventListener(
+                  eventName,
+                  _this3.events[key],
+                );
+              });
+            });
+            this.container.removeEventListener('keydown', this.handleKeyDown);
+          },
+        },
+        {
+          key: 'updateHelperPosition',
+          value: function updateHelperPosition(event) {
+            var _this$props6 = this.props,
+              lockAxis = _this$props6.lockAxis,
+              lockOffset = _this$props6.lockOffset,
+              lockToContainerEdges = _this$props6.lockToContainerEdges,
+              transitionDuration = _this$props6.transitionDuration,
+              _this$props6$keyboard =
+                _this$props6.keyboardSortingTransitionDuration,
+              keyboardSortingTransitionDuration =
+                _this$props6$keyboard === void 0
+                  ? transitionDuration
+                  : _this$props6$keyboard;
+            var isKeySorting = this.manager.isKeySorting;
+            var ignoreTransition = event.ignoreTransition;
+            var offset = getPosition(event);
+            var translate = {
+              x: offset.x - this.initialOffset.x,
+              y: offset.y - this.initialOffset.y,
+            };
+            translate.y -= window.pageYOffset - this.initialWindowScroll.top;
+            translate.x -= window.pageXOffset - this.initialWindowScroll.left;
+            this.translate = translate;
+
+            if (lockToContainerEdges) {
+              var _getLockPixelOffsets = getLockPixelOffsets({
+                  height: this.height,
+                  lockOffset: lockOffset,
+                  width: this.width,
+                }),
+                _getLockPixelOffsets2 = _slicedToArray(_getLockPixelOffsets, 2),
+                minLockOffset = _getLockPixelOffsets2[0],
+                maxLockOffset = _getLockPixelOffsets2[1];
+
+              var minOffset = {
+                x: this.width / 2 - minLockOffset.x,
+                y: this.height / 2 - minLockOffset.y,
+              };
+              var maxOffset = {
+                x: this.width / 2 - maxLockOffset.x,
+                y: this.height / 2 - maxLockOffset.y,
+              };
+              translate.x = limit(
+                this.minTranslate.x + minOffset.x,
+                this.maxTranslate.x - maxOffset.x,
+                translate.x,
+              );
+              translate.y = limit(
+                this.minTranslate.y + minOffset.y,
+                this.maxTranslate.y - maxOffset.y,
+                translate.y,
+              );
+            }
+
+            if (lockAxis === 'x') {
+              translate.y = 0;
+            } else if (lockAxis === 'y') {
+              translate.x = 0;
+            }
+
+            if (
+              isKeySorting &&
+              keyboardSortingTransitionDuration &&
+              !ignoreTransition
+            ) {
+              setTransitionDuration(
+                this.helper,
+                keyboardSortingTransitionDuration,
+              );
+            }
+
+            setTranslate3d(this.helper, translate);
+          },
+        },
+        {
+          key: 'animateNodes',
+          value: function animateNodes() {
+            var _this$props7 = this.props,
+              transitionDuration = _this$props7.transitionDuration,
+              hideSortableGhost = _this$props7.hideSortableGhost,
+              onSortOver = _this$props7.onSortOver;
+            var containerScrollDelta = this.containerScrollDelta,
+              windowScrollDelta = this.windowScrollDelta;
+            var nodes = this.manager.getOrderedRefs();
+            var sortingOffset = {
+              left:
+                this.offsetEdge.left +
+                this.translate.x +
+                containerScrollDelta.left,
+              top:
+                this.offsetEdge.top +
+                this.translate.y +
+                containerScrollDelta.top,
+            };
+            var isKeySorting = this.manager.isKeySorting;
+            var prevIndex = this.newIndex;
+            this.newIndex = null;
+
+            for (var i = 0, len = nodes.length; i < len; i++) {
+              var _node3 = nodes[i].node;
+              var index = _node3.sortableInfo.index;
+              var width = _node3.offsetWidth;
+              var height = _node3.offsetHeight;
+              var offset = {
+                height: this.height > height ? height / 2 : this.height / 2,
+                width: this.width > width ? width / 2 : this.width / 2,
+              };
+              var mustShiftBackward =
+                isKeySorting && index > this.index && index <= prevIndex;
+              var mustShiftForward =
+                isKeySorting && index < this.index && index >= prevIndex;
+              var translate = {
+                x: 0,
+                y: 0,
+              };
+              var edgeOffset = nodes[i].edgeOffset;
+
+              if (!edgeOffset) {
+                edgeOffset = getEdgeOffset(_node3, this.container);
+                nodes[i].edgeOffset = edgeOffset;
+
+                if (isKeySorting) {
+                  nodes[
+                    i
+                  ].boundingClientRect = getScrollAdjustedBoundingClientRect(
+                    _node3,
+                    containerScrollDelta,
+                  );
+                }
+              }
+
+              var nextNode = i < nodes.length - 1 && nodes[i + 1];
+              var prevNode = i > 0 && nodes[i - 1];
+
+              if (nextNode && !nextNode.edgeOffset) {
+                nextNode.edgeOffset = getEdgeOffset(
+                  nextNode.node,
+                  this.container,
+                );
+
+                if (isKeySorting) {
+                  nextNode.boundingClientRect = getScrollAdjustedBoundingClientRect(
+                    nextNode.node,
+                    containerScrollDelta,
+                  );
+                }
+              }
+
+              if (index === this.index) {
+                if (hideSortableGhost) {
+                  this.sortableGhost = _node3;
+                  setInlineStyles(_node3, {
+                    opacity: 0,
+                    visibility: 'hidden',
+                  });
+                }
+
+                continue;
+              }
+
+              if (transitionDuration) {
+                setTransitionDuration(_node3, transitionDuration);
+              }
+
+              if (this.axis.x) {
+                if (this.axis.y) {
+                  if (
+                    mustShiftForward ||
+                    (index < this.index &&
+                      ((sortingOffset.left +
+                        windowScrollDelta.left -
+                        offset.width <=
+                        edgeOffset.left &&
+                        sortingOffset.top + windowScrollDelta.top <=
+                          edgeOffset.top + offset.height) ||
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height <=
+                          edgeOffset.top))
+                  ) {
+                    translate.x = this.width + this.marginOffset.x;
+
+                    if (
+                      edgeOffset.left + translate.x >
+                      this.containerBoundingRect.width - offset.width
+                    ) {
+                      if (nextNode) {
+                        translate.x =
+                          nextNode.edgeOffset.left - edgeOffset.left;
+                        translate.y = nextNode.edgeOffset.top - edgeOffset.top;
+                      }
+                    }
+
+                    if (this.newIndex === null) {
+                      this.newIndex = index;
+                    }
+                  } else if (
+                    mustShiftBackward ||
+                    (index > this.index &&
+                      ((sortingOffset.left +
+                        windowScrollDelta.left +
+                        offset.width >=
+                        edgeOffset.left &&
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height >=
+                          edgeOffset.top) ||
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height >=
+                          edgeOffset.top + height))
+                  ) {
+                    translate.x = -(this.width + this.marginOffset.x);
+
+                    if (
+                      edgeOffset.left + translate.x <
+                      this.containerBoundingRect.left + offset.width
+                    ) {
+                      if (prevNode) {
+                        translate.x =
+                          prevNode.edgeOffset.left - edgeOffset.left;
+                        translate.y = prevNode.edgeOffset.top - edgeOffset.top;
+                      }
+                    }
+
+                    this.newIndex = index;
+                  }
+                } else {
+                  if (
+                    mustShiftBackward ||
+                    (index > this.index &&
+                      sortingOffset.left +
+                        windowScrollDelta.left +
+                        offset.width >=
+                        edgeOffset.left)
+                  ) {
+                    translate.x = -(this.width + this.marginOffset.x);
+                    this.newIndex = index;
+                  } else if (
+                    mustShiftForward ||
+                    (index < this.index &&
+                      sortingOffset.left + windowScrollDelta.left <=
+                        edgeOffset.left + offset.width)
+                  ) {
+                    translate.x = this.width + this.marginOffset.x;
+
+                    if (this.newIndex == null) {
+                      this.newIndex = index;
+                    }
+                  }
+                }
+              } else if (this.axis.y) {
+                if (
+                  mustShiftBackward ||
+                  (index > this.index &&
+                    sortingOffset.top + windowScrollDelta.top + offset.height >=
+                      edgeOffset.top)
+                ) {
+                  translate.y = -(this.height + this.marginOffset.y);
+                  this.newIndex = index;
+                } else if (
+                  mustShiftForward ||
+                  (index < this.index &&
+                    sortingOffset.top + windowScrollDelta.top <=
+                      edgeOffset.top + offset.height)
+                ) {
+                  translate.y = this.height + this.marginOffset.y;
+
+                  if (this.newIndex == null) {
+                    this.newIndex = index;
+                  }
+                }
+              }
+
+              setTranslate3d(_node3, translate);
+              nodes[i].translate = translate;
+            }
+
+            if (this.newIndex == null) {
+              this.newIndex = this.index;
+            }
+
+            if (isKeySorting) {
+              this.newIndex = prevIndex;
+            }
+
+            var oldIndex = isKeySorting ? this.prevIndex : prevIndex;
+
+            if (onSortOver && this.newIndex !== oldIndex) {
+              onSortOver({
+                collection: this.manager.active.collection,
+                index: this.index,
+                newIndex: this.newIndex,
+                oldIndex: oldIndex,
+                isKeySorting: isKeySorting,
+              });
+            }
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'getContainer',
+          value: function getContainer() {
+            var getContainer = this.props.getContainer;
+
+            if (typeof getContainer !== 'function') {
+              return findDOMNode(this);
+            }
+
+            return getContainer(
+              config.withRef ? this.getWrappedInstance() : undefined,
+            );
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                omit(this.props, omittedProps),
+              ),
+            );
+          },
+        },
+        {
+          key: 'helperContainer',
+          get: function get() {
+            var helperContainer = this.props.helperContainer;
+
+            if (typeof helperContainer === 'function') {
+              return helperContainer();
+            }
+
+            return this.props.helperContainer || this.document.body;
+          },
+        },
+        {
+          key: 'containerScrollDelta',
+          get: function get() {
+            var useWindowAsScrollContainer = this.props
+              .useWindowAsScrollContainer;
+
+            if (useWindowAsScrollContainer) {
+              return {
+                left: 0,
+                top: 0,
+              };
+            }
+
+            return {
+              left: this.scrollContainer.scrollLeft - this.initialScroll.left,
+              top: this.scrollContainer.scrollTop - this.initialScroll.top,
+            };
+          },
+        },
+        {
+          key: 'windowScrollDelta',
+          get: function get() {
+            return {
+              left:
+                this.contentWindow.pageXOffset - this.initialWindowScroll.left,
+              top:
+                this.contentWindow.pageYOffset - this.initialWindowScroll.top,
+            };
+          },
+        },
+      ]);
+
+      return WithSortableContainer;
+    })(Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableList', WrappedComponent),
+    ),
+    _defineProperty(_class, 'defaultProps', defaultProps),
+    _defineProperty(_class, 'propTypes', propTypes),
+    _defineProperty(_class, 'childContextTypes', {
+      manager: PropTypes.object.isRequired,
+    }),
+    _temp
+  );
+}
+
+var propTypes$1 = {
+  index: PropTypes.number.isRequired,
+  collection: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  disabled: PropTypes.bool,
+};
+var omittedProps$1 = Object.keys(propTypes$1);
+function sortableElement(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableElement, _React$Component);
+
+      function WithSortableElement() {
+        _classCallCheck(this, WithSortableElement);
+
+        return _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableElement).apply(this, arguments),
+        );
+      }
+
+      _createClass(WithSortableElement, [
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            this.register();
+          },
+        },
+        {
+          key: 'componentDidUpdate',
+          value: function componentDidUpdate(prevProps) {
+            if (this.node) {
+              if (prevProps.index !== this.props.index) {
+                this.node.sortableInfo.index = this.props.index;
+              }
+
+              if (prevProps.disabled !== this.props.disabled) {
+                this.node.sortableInfo.disabled = this.props.disabled;
+              }
+            }
+
+            if (prevProps.collection !== this.props.collection) {
+              this.unregister(prevProps.collection);
+              this.register();
+            }
+          },
+        },
+        {
+          key: 'componentWillUnmount',
+          value: function componentWillUnmount() {
+            this.unregister();
+          },
+        },
+        {
+          key: 'register',
+          value: function register() {
+            var _this$props = this.props,
+              collection = _this$props.collection,
+              disabled = _this$props.disabled,
+              index = _this$props.index;
+            var node = findDOMNode(this);
+            node.sortableInfo = {
+              collection: collection,
+              disabled: disabled,
+              index: index,
+              manager: this.context.manager,
+            };
+            this.node = node;
+            this.ref = {
+              node: node,
+            };
+            this.context.manager.add(collection, this.ref);
+          },
+        },
+        {
+          key: 'unregister',
+          value: function unregister() {
+            var collection =
+              arguments.length > 0 && arguments[0] !== undefined
+                ? arguments[0]
+                : this.props.collection;
+            this.context.manager.remove(collection, this.ref);
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableElement() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                omit(this.props, omittedProps$1),
+              ),
+            );
+          },
+        },
+      ]);
+
+      return WithSortableElement;
+    })(Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableElement', WrappedComponent),
+    ),
+    _defineProperty(_class, 'contextTypes', {
+      manager: PropTypes.object.isRequired,
+    }),
+    _defineProperty(_class, 'propTypes', propTypes$1),
+    _defineProperty(_class, 'defaultProps', {
+      collection: 0,
+    }),
+    _temp
+  );
+}
+
+export {
+  sortableContainer as SortableContainer,
+  sortableContainer,
+  sortableElement as SortableElement,
+  sortableElement,
+  sortableHandle as SortableHandle,
+  sortableHandle,
+  arrayMove,
+};

--- a/dist/react-sortable-hoc.js
+++ b/dist/react-sortable-hoc.js
@@ -1,0 +1,2130 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {value: true});
+
+function _interopDefault(ex) {
+  return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
+}
+
+var _extends = _interopDefault(require('@babel/runtime/helpers/extends'));
+var _slicedToArray = _interopDefault(
+  require('@babel/runtime/helpers/slicedToArray'),
+);
+var _objectSpread = _interopDefault(
+  require('@babel/runtime/helpers/objectSpread'),
+);
+var _classCallCheck = _interopDefault(
+  require('@babel/runtime/helpers/classCallCheck'),
+);
+var _createClass = _interopDefault(
+  require('@babel/runtime/helpers/createClass'),
+);
+var _possibleConstructorReturn = _interopDefault(
+  require('@babel/runtime/helpers/possibleConstructorReturn'),
+);
+var _getPrototypeOf = _interopDefault(
+  require('@babel/runtime/helpers/getPrototypeOf'),
+);
+var _inherits = _interopDefault(require('@babel/runtime/helpers/inherits'));
+var _assertThisInitialized = _interopDefault(
+  require('@babel/runtime/helpers/assertThisInitialized'),
+);
+var _defineProperty = _interopDefault(
+  require('@babel/runtime/helpers/defineProperty'),
+);
+var React = require('react');
+var PropTypes = _interopDefault(require('prop-types'));
+var reactDom = require('react-dom');
+var invariant = _interopDefault(require('invariant'));
+var _toConsumableArray = _interopDefault(
+  require('@babel/runtime/helpers/toConsumableArray'),
+);
+
+var Manager = (function() {
+  function Manager() {
+    _classCallCheck(this, Manager);
+
+    _defineProperty(this, 'refs', {});
+  }
+
+  _createClass(Manager, [
+    {
+      key: 'add',
+      value: function add(collection, ref) {
+        if (!this.refs[collection]) {
+          this.refs[collection] = [];
+        }
+
+        this.refs[collection].push(ref);
+      },
+    },
+    {
+      key: 'remove',
+      value: function remove(collection, ref) {
+        var index = this.getIndex(collection, ref);
+
+        if (index !== -1) {
+          this.refs[collection].splice(index, 1);
+        }
+      },
+    },
+    {
+      key: 'isActive',
+      value: function isActive() {
+        return this.active;
+      },
+    },
+    {
+      key: 'getActive',
+      value: function getActive() {
+        var _this = this;
+
+        return this.refs[this.active.collection].find(function(_ref) {
+          var node = _ref.node;
+          return node.sortableInfo.index == _this.active.index;
+        });
+      },
+    },
+    {
+      key: 'getIndex',
+      value: function getIndex(collection, ref) {
+        return this.refs[collection].indexOf(ref);
+      },
+    },
+    {
+      key: 'getOrderedRefs',
+      value: function getOrderedRefs() {
+        var collection =
+          arguments.length > 0 && arguments[0] !== undefined
+            ? arguments[0]
+            : this.active.collection;
+        return this.refs[collection].sort(sortByIndex);
+      },
+    },
+  ]);
+
+  return Manager;
+})();
+
+function sortByIndex(_ref2, _ref3) {
+  var index1 = _ref2.node.sortableInfo.index;
+  var index2 = _ref3.node.sortableInfo.index;
+  return index1 - index2;
+}
+
+function arrayMove(array, from, to) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof console !== 'undefined') {
+      console.warn(
+        "Deprecation warning: arrayMove will no longer be exported by 'react-sortable-hoc' in the next major release. Please install the `array-move` package locally instead. https://www.npmjs.com/package/array-move",
+      );
+    }
+  }
+
+  array = array.slice();
+  array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0]);
+  return array;
+}
+function omit(obj, keysToOmit) {
+  return Object.keys(obj).reduce(function(acc, key) {
+    if (keysToOmit.indexOf(key) === -1) {
+      acc[key] = obj[key];
+    }
+
+    return acc;
+  }, {});
+}
+var events = {
+  end: ['touchend', 'touchcancel', 'mouseup'],
+  move: ['touchmove', 'mousemove'],
+  start: ['touchstart', 'mousedown'],
+};
+var vendorPrefix = (function() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return '';
+  }
+
+  var styles = window.getComputedStyle(document.documentElement, '') || [
+    '-moz-hidden-iframe',
+  ];
+  var pre = (Array.prototype.slice
+    .call(styles)
+    .join('')
+    .match(/-(moz|webkit|ms)-/) ||
+    (styles.OLink === '' && ['', 'o']))[1];
+
+  switch (pre) {
+    case 'ms':
+      return 'ms';
+
+    default:
+      return pre && pre.length ? pre[0].toUpperCase() + pre.substr(1) : '';
+  }
+})();
+function setInlineStyles(node, styles) {
+  Object.keys(styles).forEach(function(key) {
+    node.style[key] = styles[key];
+  });
+}
+function setTranslate3d(node, translate) {
+  node.style[''.concat(vendorPrefix, 'Transform')] =
+    translate == null
+      ? ''
+      : 'translate3d('.concat(translate.x, 'px,').concat(translate.y, 'px,0)');
+}
+function setTransitionDuration(node, duration) {
+  node.style[''.concat(vendorPrefix, 'TransitionDuration')] =
+    duration == null ? '' : ''.concat(duration, 'ms');
+}
+function closest(el, fn) {
+  while (el) {
+    if (fn(el)) {
+      return el;
+    }
+
+    el = el.parentNode;
+  }
+
+  return null;
+}
+function limit(min, max, value) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function getPixelValue(stringValue) {
+  if (stringValue.substr(-2) === 'px') {
+    return parseFloat(stringValue);
+  }
+
+  return 0;
+}
+
+function getElementMargin(element) {
+  var style = window.getComputedStyle(element);
+  return {
+    bottom: getPixelValue(style.marginBottom),
+    left: getPixelValue(style.marginLeft),
+    right: getPixelValue(style.marginRight),
+    top: getPixelValue(style.marginTop),
+  };
+}
+function provideDisplayName(prefix, Component) {
+  var componentName = Component.displayName || Component.name;
+  return componentName
+    ? ''.concat(prefix, '(').concat(componentName, ')')
+    : prefix;
+}
+function getScrollAdjustedBoundingClientRect(node, scrollDelta) {
+  var boundingClientRect = node.getBoundingClientRect();
+  return {
+    top: boundingClientRect.top + scrollDelta.top,
+    left: boundingClientRect.left + scrollDelta.left,
+  };
+}
+function getPosition(event) {
+  if (event.touches && event.touches.length) {
+    return {
+      x: event.touches[0].pageX,
+      y: event.touches[0].pageY,
+    };
+  } else if (event.changedTouches && event.changedTouches.length) {
+    return {
+      x: event.changedTouches[0].pageX,
+      y: event.changedTouches[0].pageY,
+    };
+  } else {
+    return {
+      x: event.pageX,
+      y: event.pageY,
+    };
+  }
+}
+function isTouchEvent(event) {
+  return (
+    (event.touches && event.touches.length) ||
+    (event.changedTouches && event.changedTouches.length)
+  );
+}
+function getEdgeOffset(node, parent) {
+  var offset =
+    arguments.length > 2 && arguments[2] !== undefined
+      ? arguments[2]
+      : {
+          left: 0,
+          top: 0,
+        };
+
+  if (!node) {
+    return undefined;
+  }
+
+  var nodeOffset = {
+    left: offset.left + node.offsetLeft,
+    top: offset.top + node.offsetTop,
+  };
+
+  if (node.parentNode === parent) {
+    return nodeOffset;
+  }
+
+  return getEdgeOffset(node.parentNode, parent, nodeOffset);
+}
+function getTargetIndex(newIndex, prevIndex, oldIndex) {
+  if (newIndex < oldIndex && newIndex > prevIndex) {
+    return newIndex - 1;
+  } else if (newIndex > oldIndex && newIndex < prevIndex) {
+    return newIndex + 1;
+  } else {
+    return newIndex;
+  }
+}
+function getLockPixelOffset(_ref) {
+  var lockOffset = _ref.lockOffset,
+    width = _ref.width,
+    height = _ref.height;
+  var offsetX = lockOffset;
+  var offsetY = lockOffset;
+  var unit = 'px';
+
+  if (typeof lockOffset === 'string') {
+    var match = /^[+-]?\d*(?:\.\d*)?(px|%)$/.exec(lockOffset);
+    invariant(
+      match !== null,
+      'lockOffset value should be a number or a string of a ' +
+        'number followed by "px" or "%". Given %s',
+      lockOffset,
+    );
+    offsetX = parseFloat(lockOffset);
+    offsetY = parseFloat(lockOffset);
+    unit = match[1];
+  }
+
+  invariant(
+    isFinite(offsetX) && isFinite(offsetY),
+    'lockOffset value should be a finite. Given %s',
+    lockOffset,
+  );
+
+  if (unit === '%') {
+    offsetX = (offsetX * width) / 100;
+    offsetY = (offsetY * height) / 100;
+  }
+
+  return {
+    x: offsetX,
+    y: offsetY,
+  };
+}
+function getLockPixelOffsets(_ref2) {
+  var height = _ref2.height,
+    width = _ref2.width,
+    lockOffset = _ref2.lockOffset;
+  var offsets = Array.isArray(lockOffset)
+    ? lockOffset
+    : [lockOffset, lockOffset];
+  invariant(
+    offsets.length === 2,
+    'lockOffset prop of SortableContainer should be a single ' +
+      'value or an array of exactly two values. Given %s',
+    lockOffset,
+  );
+
+  var _offsets = _slicedToArray(offsets, 2),
+    minLockOffset = _offsets[0],
+    maxLockOffset = _offsets[1];
+
+  return [
+    getLockPixelOffset({
+      height: height,
+      lockOffset: minLockOffset,
+      width: width,
+    }),
+    getLockPixelOffset({
+      height: height,
+      lockOffset: maxLockOffset,
+      width: width,
+    }),
+  ];
+}
+
+function isScrollable(el) {
+  var computedStyle = window.getComputedStyle(el);
+  var overflowRegex = /(auto|scroll)/;
+  var properties = ['overflow', 'overflowX', 'overflowY'];
+  return properties.find(function(property) {
+    return overflowRegex.test(computedStyle[property]);
+  });
+}
+
+function getScrollingParent(el) {
+  if (!(el instanceof HTMLElement)) {
+    return null;
+  } else if (isScrollable(el)) {
+    return el;
+  } else {
+    return getScrollingParent(el.parentNode);
+  }
+}
+var KEYCODE = {
+  TAB: 9,
+  ESC: 27,
+  SPACE: 32,
+  LEFT: 37,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
+};
+var NodeType = {
+  Anchor: 'A',
+  Button: 'BUTTON',
+  Canvas: 'CANVAS',
+  Input: 'INPUT',
+  Option: 'OPTION',
+  Textarea: 'TEXTAREA',
+  Select: 'SELECT',
+};
+function cloneNode(node) {
+  var selector = 'input, textarea, select, canvas, [contenteditable]';
+  var fields = node.querySelectorAll(selector);
+  var clonedNode = node.cloneNode(true);
+
+  var clonedFields = _toConsumableArray(clonedNode.querySelectorAll(selector));
+
+  clonedFields.forEach(function(field, i) {
+    if (field.type !== 'file') {
+      field.value = fields[i].value;
+    }
+
+    if (field.type === 'radio' && field.name) {
+      field.name = '__sortableClone__'.concat(field.name);
+    }
+
+    if (
+      field.tagName === NodeType.Canvas &&
+      fields[i].width > 0 &&
+      fields[i].height > 0
+    ) {
+      var destCtx = field.getContext('2d');
+      destCtx.drawImage(fields[i], 0, 0);
+    }
+  });
+  return clonedNode;
+}
+
+function sortableHandle(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableHandle, _React$Component);
+
+      function WithSortableHandle() {
+        _classCallCheck(this, WithSortableHandle);
+
+        return _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableHandle).apply(this, arguments),
+        );
+      }
+
+      _createClass(WithSortableHandle, [
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            var node = reactDom.findDOMNode(this);
+            node.sortableHandle = true;
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableHandle() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return React.createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                this.props,
+              ),
+            );
+          },
+        },
+      ]);
+
+      return WithSortableHandle;
+    })(React.Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableHandle', WrappedComponent),
+    ),
+    _temp
+  );
+}
+function isSortableHandle(node) {
+  return node.sortableHandle != null;
+}
+
+var AutoScroller = (function() {
+  function AutoScroller(container, onScrollCallback) {
+    _classCallCheck(this, AutoScroller);
+
+    this.container = container;
+    this.onScrollCallback = onScrollCallback;
+  }
+
+  _createClass(AutoScroller, [
+    {
+      key: 'clear',
+      value: function clear() {
+        if (this.interval == null) {
+          return;
+        }
+
+        clearInterval(this.interval);
+        this.interval = null;
+      },
+    },
+    {
+      key: 'update',
+      value: function update(_ref) {
+        var _this = this;
+
+        var translate = _ref.translate,
+          minTranslate = _ref.minTranslate,
+          maxTranslate = _ref.maxTranslate,
+          width = _ref.width,
+          height = _ref.height;
+        var direction = {
+          x: 0,
+          y: 0,
+        };
+        var speed = {
+          x: 1,
+          y: 1,
+        };
+        var acceleration = {
+          x: 10,
+          y: 10,
+        };
+        var _this$container = this.container,
+          scrollTop = _this$container.scrollTop,
+          scrollLeft = _this$container.scrollLeft,
+          scrollHeight = _this$container.scrollHeight,
+          scrollWidth = _this$container.scrollWidth,
+          clientHeight = _this$container.clientHeight,
+          clientWidth = _this$container.clientWidth;
+        var isTop = scrollTop === 0;
+        var isBottom = scrollHeight - scrollTop - clientHeight === 0;
+        var isLeft = scrollLeft === 0;
+        var isRight = scrollWidth - scrollLeft - clientWidth === 0;
+
+        if (translate.y >= maxTranslate.y - height / 2 && !isBottom) {
+          direction.y = 1;
+          speed.y =
+            acceleration.y *
+            Math.abs((maxTranslate.y - height / 2 - translate.y) / height);
+        } else if (translate.x >= maxTranslate.x - width / 2 && !isRight) {
+          direction.x = 1;
+          speed.x =
+            acceleration.x *
+            Math.abs((maxTranslate.x - width / 2 - translate.x) / width);
+        } else if (translate.y <= minTranslate.y + height / 2 && !isTop) {
+          direction.y = -1;
+          speed.y =
+            acceleration.y *
+            Math.abs((translate.y - height / 2 - minTranslate.y) / height);
+        } else if (translate.x <= minTranslate.x + width / 2 && !isLeft) {
+          direction.x = -1;
+          speed.x =
+            acceleration.x *
+            Math.abs((translate.x - width / 2 - minTranslate.x) / width);
+        }
+
+        if (this.interval) {
+          this.clear();
+          this.isAutoScrolling = false;
+        }
+
+        if (direction.x !== 0 || direction.y !== 0) {
+          this.interval = setInterval(function() {
+            _this.isAutoScrolling = true;
+            var offset = {
+              left: speed.x * direction.x,
+              top: speed.y * direction.y,
+            };
+            _this.container.scrollTop += offset.top;
+            _this.container.scrollLeft += offset.left;
+
+            _this.onScrollCallback(offset);
+          }, 5);
+        }
+      },
+    },
+  ]);
+
+  return AutoScroller;
+})();
+
+function defaultGetHelperDimensions(_ref) {
+  var node = _ref.node;
+  return {
+    height: node.offsetHeight,
+    width: node.offsetWidth,
+  };
+}
+
+function defaultShouldCancelStart(event) {
+  var interactiveElements = [
+    NodeType.Input,
+    NodeType.Textarea,
+    NodeType.Select,
+    NodeType.Option,
+    NodeType.Button,
+  ];
+
+  if (interactiveElements.indexOf(event.target.tagName) !== -1) {
+    return true;
+  }
+
+  if (
+    closest(event.target, function(el) {
+      return el.contentEditable === 'true';
+    })
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+var propTypes = {
+  axis: PropTypes.oneOf(['x', 'y', 'xy']),
+  contentWindow: PropTypes.any,
+  disableAutoscroll: PropTypes.bool,
+  distance: PropTypes.number,
+  getContainer: PropTypes.func,
+  getHelperDimensions: PropTypes.func,
+  helperClass: PropTypes.string,
+  helperContainer: PropTypes.oneOfType([
+    PropTypes.func,
+    typeof HTMLElement === 'undefined'
+      ? PropTypes.any
+      : PropTypes.instanceOf(HTMLElement),
+  ]),
+  hideSortableGhost: PropTypes.bool,
+  keyboardSortingTransitionDuration: PropTypes.number,
+  lockAxis: PropTypes.string,
+  lockOffset: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    ),
+  ]),
+  lockToContainerEdges: PropTypes.bool,
+  onSortEnd: PropTypes.func,
+  onSortMove: PropTypes.func,
+  onSortOver: PropTypes.func,
+  onSortStart: PropTypes.func,
+  pressDelay: PropTypes.number,
+  pressThreshold: PropTypes.number,
+  keyCodes: PropTypes.shape({
+    lift: PropTypes.arrayOf(PropTypes.number),
+    drop: PropTypes.arrayOf(PropTypes.number),
+    cancel: PropTypes.arrayOf(PropTypes.number),
+    up: PropTypes.arrayOf(PropTypes.number),
+    down: PropTypes.arrayOf(PropTypes.number),
+  }),
+  shouldCancelStart: PropTypes.func,
+  transitionDuration: PropTypes.number,
+  updateBeforeSortStart: PropTypes.func,
+  useDragHandle: PropTypes.bool,
+  useWindowAsScrollContainer: PropTypes.bool,
+};
+var defaultKeyCodes = {
+  lift: [KEYCODE.SPACE],
+  drop: [KEYCODE.SPACE],
+  cancel: [KEYCODE.ESC],
+  up: [KEYCODE.UP, KEYCODE.LEFT],
+  down: [KEYCODE.DOWN, KEYCODE.RIGHT],
+};
+var defaultProps = {
+  axis: 'y',
+  disableAutoscroll: false,
+  distance: 0,
+  getHelperDimensions: defaultGetHelperDimensions,
+  hideSortableGhost: true,
+  lockOffset: '50%',
+  lockToContainerEdges: false,
+  pressDelay: 0,
+  pressThreshold: 5,
+  keyCodes: defaultKeyCodes,
+  shouldCancelStart: defaultShouldCancelStart,
+  transitionDuration: 300,
+  useWindowAsScrollContainer: false,
+};
+var omittedProps = Object.keys(propTypes);
+function validateProps(props) {
+  invariant(
+    !(props.distance && props.pressDelay),
+    'Attempted to set both `pressDelay` and `distance` on SortableContainer, you may only use one or the other, not both at the same time.',
+  );
+}
+
+function _finallyRethrows(body, finalizer) {
+  try {
+    var result = body();
+  } catch (e) {
+    return finalizer(true, e);
+  }
+
+  if (result && result.then) {
+    return result.then(finalizer.bind(null, false), finalizer.bind(null, true));
+  }
+
+  return finalizer(false, value);
+}
+function sortableContainer(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableContainer, _React$Component);
+
+      function WithSortableContainer(props) {
+        var _this;
+
+        _classCallCheck(this, WithSortableContainer);
+
+        _this = _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableContainer).call(this, props),
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'state',
+          {},
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleStart',
+          function(event) {
+            var _this$props = _this.props,
+              distance = _this$props.distance,
+              shouldCancelStart = _this$props.shouldCancelStart;
+
+            if (event.button === 2 || shouldCancelStart(event)) {
+              return;
+            }
+
+            _this.touched = true;
+            _this.position = getPosition(event);
+            var node = closest(event.target, function(el) {
+              return el.sortableInfo != null;
+            });
+
+            if (
+              node &&
+              node.sortableInfo &&
+              _this.nodeIsChild(node) &&
+              !_this.state.sorting
+            ) {
+              var useDragHandle = _this.props.useDragHandle;
+              var _node$sortableInfo = node.sortableInfo,
+                index = _node$sortableInfo.index,
+                collection = _node$sortableInfo.collection,
+                disabled = _node$sortableInfo.disabled;
+
+              if (disabled) {
+                return;
+              }
+
+              if (useDragHandle && !closest(event.target, isSortableHandle)) {
+                return;
+              }
+
+              _this.manager.active = {
+                collection: collection,
+                index: index,
+              };
+
+              if (
+                !isTouchEvent(event) &&
+                event.target.tagName === NodeType.Anchor
+              ) {
+                event.preventDefault();
+              }
+
+              if (!distance) {
+                if (_this.props.pressDelay === 0) {
+                  _this.handlePress(event);
+                } else {
+                  _this.pressTimer = setTimeout(function() {
+                    return _this.handlePress(event);
+                  }, _this.props.pressDelay);
+                }
+              }
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'nodeIsChild',
+          function(node) {
+            return node.sortableInfo.manager === _this.manager;
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleMove',
+          function(event) {
+            var _this$props2 = _this.props,
+              distance = _this$props2.distance,
+              pressThreshold = _this$props2.pressThreshold;
+
+            if (
+              !_this.state.sorting &&
+              _this.touched &&
+              !_this._awaitingUpdateBeforeSortStart
+            ) {
+              var position = getPosition(event);
+              var delta = {
+                x: _this.position.x - position.x,
+                y: _this.position.y - position.y,
+              };
+              var combinedDelta = Math.abs(delta.x) + Math.abs(delta.y);
+              _this.delta = delta;
+
+              if (
+                !distance &&
+                (!pressThreshold || combinedDelta >= pressThreshold)
+              ) {
+                clearTimeout(_this.cancelTimer);
+                _this.cancelTimer = setTimeout(_this.cancel, 0);
+              } else if (
+                distance &&
+                combinedDelta >= distance &&
+                _this.manager.isActive()
+              ) {
+                _this.handlePress(event);
+              }
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleEnd',
+          function() {
+            _this.touched = false;
+
+            _this.cancel();
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'cancel',
+          function() {
+            var distance = _this.props.distance;
+            var sorting = _this.state.sorting;
+
+            if (!sorting) {
+              if (!distance) {
+                clearTimeout(_this.pressTimer);
+              }
+
+              _this.manager.active = null;
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handlePress',
+          function(event) {
+            try {
+              var _exit2 = false;
+
+              var active = _this.manager.getActive();
+
+              return Promise.resolve(
+                (function() {
+                  if (active) {
+                    var _temp4 = function _temp4(_result2) {
+                      if (_exit2) return _result2;
+                      var index = _node.sortableInfo.index;
+                      var margin = getElementMargin(_node);
+
+                      var containerBoundingRect = _this.scrollContainer.getBoundingClientRect();
+
+                      var dimensions = _getHelperDimensions({
+                        collection: _collection,
+                        index: index,
+                        node: _node,
+                      });
+
+                      _this.node = _node;
+                      _this.margin = margin;
+                      _this.width = dimensions.width;
+                      _this.height = dimensions.height;
+                      _this.marginOffset = {
+                        x: _this.margin.left + _this.margin.right,
+                        y: Math.max(_this.margin.top, _this.margin.bottom),
+                      };
+                      _this.boundingClientRect = _node.getBoundingClientRect();
+                      _this.containerBoundingRect = containerBoundingRect;
+                      _this.index = index;
+                      _this.newIndex = index;
+                      _this.axis = {
+                        x: _axis.indexOf('x') >= 0,
+                        y: _axis.indexOf('y') >= 0,
+                      };
+                      _this.offsetEdge = getEdgeOffset(_node, _this.container);
+
+                      if (_isKeySorting) {
+                        _this.initialOffset = getPosition(
+                          _objectSpread({}, event, {
+                            pageX: _this.boundingClientRect.left,
+                            pageY: _this.boundingClientRect.top,
+                          }),
+                        );
+                      } else {
+                        _this.initialOffset = getPosition(event);
+                      }
+
+                      _this.initialScroll = {
+                        left: _this.scrollContainer.scrollLeft,
+                        top: _this.scrollContainer.scrollTop,
+                      };
+                      _this.initialWindowScroll = {
+                        left: window.pageXOffset,
+                        top: window.pageYOffset,
+                      };
+                      _this.helper = _this.helperContainer.appendChild(
+                        cloneNode(_node),
+                      );
+                      setInlineStyles(_this.helper, {
+                        boxSizing: 'border-box',
+                        height: ''.concat(_this.height, 'px'),
+                        left: ''.concat(
+                          _this.boundingClientRect.left - margin.left,
+                          'px',
+                        ),
+                        pointerEvents: 'none',
+                        position: 'fixed',
+                        top: ''.concat(
+                          _this.boundingClientRect.top - margin.top,
+                          'px',
+                        ),
+                        width: ''.concat(_this.width, 'px'),
+                      });
+
+                      if (_isKeySorting) {
+                        _this.helper.focus();
+                      }
+
+                      if (_hideSortableGhost) {
+                        _this.sortableGhost = _node;
+                        setInlineStyles(_node, {
+                          opacity: 0,
+                          visibility: 'hidden',
+                        });
+                      }
+
+                      _this.minTranslate = {};
+                      _this.maxTranslate = {};
+
+                      if (_isKeySorting) {
+                        var _ref = _useWindowAsScrollContainer
+                            ? {
+                                top: 0,
+                                left: 0,
+                                width: _this.contentWindow.innerWidth,
+                                height: _this.contentWindow.innerHeight,
+                              }
+                            : _this.containerBoundingRect,
+                          containerTop = _ref.top,
+                          containerLeft = _ref.left,
+                          containerWidth = _ref.width,
+                          containerHeight = _ref.height;
+
+                        var containerBottom = containerTop + containerHeight;
+                        var containerRight = containerLeft + containerWidth;
+
+                        if (_this.axis.x) {
+                          _this.minTranslate.x =
+                            containerLeft - _this.boundingClientRect.left;
+                          _this.maxTranslate.x =
+                            containerRight -
+                            (_this.boundingClientRect.left + _this.width);
+                        }
+
+                        if (_this.axis.y) {
+                          _this.minTranslate.y =
+                            containerTop - _this.boundingClientRect.top;
+                          _this.maxTranslate.y =
+                            containerBottom -
+                            (_this.boundingClientRect.top + _this.height);
+                        }
+                      } else {
+                        if (_this.axis.x) {
+                          _this.minTranslate.x =
+                            (_useWindowAsScrollContainer
+                              ? 0
+                              : containerBoundingRect.left) -
+                            _this.boundingClientRect.left -
+                            _this.width / 2;
+                          _this.maxTranslate.x =
+                            (_useWindowAsScrollContainer
+                              ? _this.contentWindow.innerWidth
+                              : containerBoundingRect.left +
+                                containerBoundingRect.width) -
+                            _this.boundingClientRect.left -
+                            _this.width / 2;
+                        }
+
+                        if (_this.axis.y) {
+                          _this.minTranslate.y =
+                            (_useWindowAsScrollContainer
+                              ? 0
+                              : containerBoundingRect.top) -
+                            _this.boundingClientRect.top -
+                            _this.height / 2;
+                          _this.maxTranslate.y =
+                            (_useWindowAsScrollContainer
+                              ? _this.contentWindow.innerHeight
+                              : containerBoundingRect.top +
+                                containerBoundingRect.height) -
+                            _this.boundingClientRect.top -
+                            _this.height / 2;
+                        }
+                      }
+
+                      if (_helperClass) {
+                        _helperClass.split(' ').forEach(function(className) {
+                          return _this.helper.classList.add(className);
+                        });
+                      }
+
+                      _this.listenerNode = event.touches
+                        ? _node
+                        : _this.contentWindow;
+
+                      if (_isKeySorting) {
+                        _this.listenerNode.addEventListener(
+                          'wheel',
+                          _this.handleKeyEnd,
+                          true,
+                        );
+
+                        _this.listenerNode.addEventListener(
+                          'mousedown',
+                          _this.handleKeyEnd,
+                          true,
+                        );
+
+                        _this.listenerNode.addEventListener(
+                          'keydown',
+                          _this.handleKeyDown,
+                        );
+                      } else {
+                        events.move.forEach(function(eventName) {
+                          return _this.listenerNode.addEventListener(
+                            eventName,
+                            _this.handleSortMove,
+                            false,
+                          );
+                        });
+                        events.end.forEach(function(eventName) {
+                          return _this.listenerNode.addEventListener(
+                            eventName,
+                            _this.handleSortEnd,
+                            false,
+                          );
+                        });
+                      }
+
+                      _this.setState({
+                        sorting: true,
+                        sortingIndex: index,
+                      });
+
+                      if (_onSortStart) {
+                        _onSortStart(
+                          {
+                            node: _node,
+                            index: index,
+                            collection: _collection,
+                            isKeySorting: _isKeySorting,
+                          },
+                          event,
+                        );
+                      }
+
+                      if (_isKeySorting) {
+                        _this.keyMove(0);
+                      }
+                    };
+
+                    var _this$props3 = _this.props,
+                      _axis = _this$props3.axis,
+                      _getHelperDimensions = _this$props3.getHelperDimensions,
+                      _helperClass = _this$props3.helperClass,
+                      _hideSortableGhost = _this$props3.hideSortableGhost,
+                      updateBeforeSortStart =
+                        _this$props3.updateBeforeSortStart,
+                      _onSortStart = _this$props3.onSortStart,
+                      _useWindowAsScrollContainer =
+                        _this$props3.useWindowAsScrollContainer;
+                    var _node = active.node,
+                      _collection = active.collection;
+                    var _isKeySorting = _this.manager.isKeySorting;
+
+                    var _temp5 = (function() {
+                      if (typeof updateBeforeSortStart === 'function') {
+                        _this._awaitingUpdateBeforeSortStart = true;
+                        return _finallyRethrows(
+                          function() {
+                            var index = _node.sortableInfo.index;
+                            return Promise.resolve(
+                              updateBeforeSortStart(
+                                {
+                                  collection: _collection,
+                                  index: index,
+                                  node: _node,
+                                  isKeySorting: _isKeySorting,
+                                },
+                                event,
+                              ),
+                            ).then(function(result) {
+                              if (result === false) {
+                                _exit2 = true;
+                              }
+                            });
+                          },
+                          function(_wasThrown, _result) {
+                            _this._awaitingUpdateBeforeSortStart = false;
+                            if (_wasThrown) throw _result;
+                            return _result;
+                          },
+                        );
+                      }
+                    })();
+
+                    return _temp5 && _temp5.then
+                      ? _temp5.then(_temp4)
+                      : _temp4(_temp5);
+                  }
+                })(),
+              );
+            } catch (e) {
+              return Promise.reject(e);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleSortMove',
+          function(event) {
+            var onSortMove = _this.props.onSortMove;
+
+            if (typeof event.preventDefault === 'function') {
+              event.preventDefault();
+            }
+
+            _this.updateHelperPosition(event);
+
+            _this.animateNodes();
+
+            _this.autoscroll();
+
+            if (onSortMove) {
+              onSortMove(event);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleSortEnd',
+          function(event) {
+            var _this$props4 = _this.props,
+              hideSortableGhost = _this$props4.hideSortableGhost,
+              onSortEnd = _this$props4.onSortEnd;
+            var _this$manager = _this.manager,
+              collection = _this$manager.active.collection,
+              isKeySorting = _this$manager.isKeySorting;
+            var nodes = _this.manager.refs[collection];
+
+            if (_this.listenerNode) {
+              if (isKeySorting) {
+                _this.listenerNode.removeEventListener(
+                  'wheel',
+                  _this.handleKeyEnd,
+                  true,
+                );
+
+                _this.listenerNode.removeEventListener(
+                  'mousedown',
+                  _this.handleKeyEnd,
+                  true,
+                );
+
+                _this.listenerNode.removeEventListener(
+                  'keydown',
+                  _this.handleKeyDown,
+                );
+              } else {
+                events.move.forEach(function(eventName) {
+                  return _this.listenerNode.removeEventListener(
+                    eventName,
+                    _this.handleSortMove,
+                  );
+                });
+                events.end.forEach(function(eventName) {
+                  return _this.listenerNode.removeEventListener(
+                    eventName,
+                    _this.handleSortEnd,
+                  );
+                });
+              }
+            }
+
+            _this.helper.parentNode.removeChild(_this.helper);
+
+            if (hideSortableGhost && _this.sortableGhost) {
+              setInlineStyles(_this.sortableGhost, {
+                opacity: '',
+                visibility: '',
+              });
+            }
+
+            for (var i = 0, len = nodes.length; i < len; i++) {
+              var _node2 = nodes[i];
+              var el = _node2.node;
+              _node2.edgeOffset = null;
+              _node2.boundingClientRect = null;
+              setTranslate3d(el, null);
+              setTransitionDuration(el, null);
+              _node2.translate = null;
+            }
+
+            _this.autoScroller.clear();
+
+            _this.manager.active = null;
+            _this.manager.isKeySorting = false;
+
+            _this.setState({
+              sorting: false,
+              sortingIndex: null,
+            });
+
+            if (typeof onSortEnd === 'function') {
+              onSortEnd(
+                {
+                  collection: collection,
+                  newIndex: _this.newIndex,
+                  oldIndex: _this.index,
+                  isKeySorting: isKeySorting,
+                },
+                event,
+              );
+            }
+
+            _this.touched = false;
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'autoscroll',
+          function() {
+            var disableAutoscroll = _this.props.disableAutoscroll;
+            var isKeySorting = _this.manager.isKeySorting;
+
+            if (disableAutoscroll) {
+              _this.autoScroller.clear();
+
+              return;
+            }
+
+            if (isKeySorting) {
+              var translate = _objectSpread({}, _this.translate);
+
+              var scrollX = 0;
+              var scrollY = 0;
+
+              if (_this.axis.x) {
+                translate.x = Math.min(
+                  _this.maxTranslate.x,
+                  Math.max(_this.minTranslate.x, _this.translate.x),
+                );
+                scrollX = _this.translate.x - translate.x;
+              }
+
+              if (_this.axis.y) {
+                translate.y = Math.min(
+                  _this.maxTranslate.y,
+                  Math.max(_this.minTranslate.y, _this.translate.y),
+                );
+                scrollY = _this.translate.y - translate.y;
+              }
+
+              _this.translate = translate;
+              setTranslate3d(_this.helper, _this.translate);
+              _this.scrollContainer.scrollLeft += scrollX;
+              _this.scrollContainer.scrollTop += scrollY;
+              return;
+            }
+
+            _this.autoScroller.update({
+              height: _this.height,
+              maxTranslate: _this.maxTranslate,
+              minTranslate: _this.minTranslate,
+              translate: _this.translate,
+              width: _this.width,
+            });
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'onAutoScroll',
+          function(offset) {
+            _this.translate.x += offset.left;
+            _this.translate.y += offset.top;
+
+            _this.animateNodes();
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleKeyDown',
+          function(event) {
+            var keyCode = event.keyCode;
+            var _this$props5 = _this.props,
+              shouldCancelStart = _this$props5.shouldCancelStart,
+              _this$props5$keyCodes = _this$props5.keyCodes,
+              customKeyCodes =
+                _this$props5$keyCodes === void 0 ? {} : _this$props5$keyCodes;
+
+            var keyCodes = _objectSpread({}, defaultKeyCodes, customKeyCodes);
+
+            if (
+              (_this.manager.active && !_this.manager.isKeySorting) ||
+              (!_this.manager.active &&
+                (!keyCodes.lift.includes(keyCode) ||
+                  shouldCancelStart(event) ||
+                  !_this.isValidSortingTarget(event)))
+            ) {
+              return;
+            }
+
+            event.stopPropagation();
+            event.preventDefault();
+
+            if (keyCodes.lift.includes(keyCode) && !_this.manager.active) {
+              _this.keyLift(event);
+            } else if (
+              keyCodes.drop.includes(keyCode) &&
+              _this.manager.active
+            ) {
+              _this.keyDrop(event);
+            } else if (keyCodes.cancel.includes(keyCode)) {
+              _this.newIndex = _this.manager.active.index;
+
+              _this.keyDrop(event);
+            } else if (keyCodes.up.includes(keyCode)) {
+              _this.keyMove(-1);
+            } else if (keyCodes.down.includes(keyCode)) {
+              _this.keyMove(1);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyLift',
+          function(event) {
+            var target = event.target;
+            var node = closest(target, function(el) {
+              return el.sortableInfo != null;
+            });
+            var _node$sortableInfo2 = node.sortableInfo,
+              index = _node$sortableInfo2.index,
+              collection = _node$sortableInfo2.collection;
+            _this.initialFocusedNode = target;
+            _this.manager.isKeySorting = true;
+            _this.manager.active = {
+              index: index,
+              collection: collection,
+            };
+
+            _this.handlePress(event);
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyMove',
+          function(shift) {
+            var nodes = _this.manager.getOrderedRefs();
+
+            var lastIndex = nodes[nodes.length - 1].node.sortableInfo.index;
+            var newIndex = _this.newIndex + shift;
+            var prevIndex = _this.newIndex;
+
+            if (newIndex < 0 || newIndex > lastIndex) {
+              return;
+            }
+
+            _this.prevIndex = prevIndex;
+            _this.newIndex = newIndex;
+            var targetIndex = getTargetIndex(
+              _this.newIndex,
+              _this.prevIndex,
+              _this.index,
+            );
+            var target = nodes.find(function(_ref2) {
+              var node = _ref2.node;
+              return node.sortableInfo.index === targetIndex;
+            });
+            var targetNode = target.node;
+            var scrollDelta = _this.containerScrollDelta;
+            var targetBoundingClientRect =
+              target.boundingClientRect ||
+              getScrollAdjustedBoundingClientRect(targetNode, scrollDelta);
+            var targetTranslate = target.translate || {
+              x: 0,
+              y: 0,
+            };
+            var targetPosition = {
+              top:
+                targetBoundingClientRect.top +
+                targetTranslate.y -
+                scrollDelta.top,
+              left:
+                targetBoundingClientRect.left +
+                targetTranslate.x -
+                scrollDelta.left,
+            };
+            var shouldAdjustForSize = prevIndex < newIndex;
+            var sizeAdjustment = {
+              x:
+                shouldAdjustForSize && _this.axis.x
+                  ? targetNode.offsetWidth - _this.width
+                  : 0,
+              y:
+                shouldAdjustForSize && _this.axis.y
+                  ? targetNode.offsetHeight - _this.height
+                  : 0,
+            };
+
+            _this.handleSortMove({
+              pageX: targetPosition.left + sizeAdjustment.x,
+              pageY: targetPosition.top + sizeAdjustment.y,
+              ignoreTransition: shift === 0,
+            });
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'keyDrop',
+          function(event) {
+            _this.handleSortEnd(event);
+
+            if (_this.initialFocusedNode) {
+              _this.initialFocusedNode.focus();
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'handleKeyEnd',
+          function(event) {
+            if (_this.manager.active) {
+              _this.keyDrop(event);
+            }
+          },
+        );
+
+        _defineProperty(
+          _assertThisInitialized(_assertThisInitialized(_this)),
+          'isValidSortingTarget',
+          function(event) {
+            var useDragHandle = _this.props.useDragHandle;
+            var target = event.target;
+            var node = closest(target, function(el) {
+              return el.sortableInfo != null;
+            });
+            return (
+              node &&
+              node.sortableInfo &&
+              !node.sortableInfo.disabled &&
+              (useDragHandle ? isSortableHandle(target) : target.sortableInfo)
+            );
+          },
+        );
+
+        validateProps(props);
+        _this.manager = new Manager();
+        _this.events = {
+          end: _this.handleEnd,
+          move: _this.handleMove,
+          start: _this.handleStart,
+        };
+        return _this;
+      }
+
+      _createClass(WithSortableContainer, [
+        {
+          key: 'getChildContext',
+          value: function getChildContext() {
+            return {
+              manager: this.manager,
+            };
+          },
+        },
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            var _this2 = this;
+
+            var useWindowAsScrollContainer = this.props
+              .useWindowAsScrollContainer;
+            var container = this.getContainer();
+            Promise.resolve(container).then(function(containerNode) {
+              _this2.container = containerNode;
+              _this2.document = _this2.container.ownerDocument || document;
+              var contentWindow =
+                _this2.props.contentWindow ||
+                _this2.document.defaultView ||
+                window;
+              _this2.contentWindow =
+                typeof contentWindow === 'function'
+                  ? contentWindow()
+                  : contentWindow;
+              _this2.scrollContainer = useWindowAsScrollContainer
+                ? _this2.document.scrollingElement ||
+                  _this2.document.documentElement
+                : getScrollingParent(_this2.container) || _this2.container;
+              _this2.autoScroller = new AutoScroller(
+                _this2.scrollContainer,
+                _this2.onAutoScroll,
+              );
+              Object.keys(_this2.events).forEach(function(key) {
+                return events[key].forEach(function(eventName) {
+                  return _this2.container.addEventListener(
+                    eventName,
+                    _this2.events[key],
+                    false,
+                  );
+                });
+              });
+
+              _this2.container.addEventListener(
+                'keydown',
+                _this2.handleKeyDown,
+              );
+            });
+          },
+        },
+        {
+          key: 'componentWillUnmount',
+          value: function componentWillUnmount() {
+            var _this3 = this;
+
+            if (this.helper && this.helper.parentNode) {
+              this.helper.parentNode.removeChild(this.helper);
+            }
+
+            if (!this.container) {
+              return;
+            }
+
+            Object.keys(this.events).forEach(function(key) {
+              return events[key].forEach(function(eventName) {
+                return _this3.container.removeEventListener(
+                  eventName,
+                  _this3.events[key],
+                );
+              });
+            });
+            this.container.removeEventListener('keydown', this.handleKeyDown);
+          },
+        },
+        {
+          key: 'updateHelperPosition',
+          value: function updateHelperPosition(event) {
+            var _this$props6 = this.props,
+              lockAxis = _this$props6.lockAxis,
+              lockOffset = _this$props6.lockOffset,
+              lockToContainerEdges = _this$props6.lockToContainerEdges,
+              transitionDuration = _this$props6.transitionDuration,
+              _this$props6$keyboard =
+                _this$props6.keyboardSortingTransitionDuration,
+              keyboardSortingTransitionDuration =
+                _this$props6$keyboard === void 0
+                  ? transitionDuration
+                  : _this$props6$keyboard;
+            var isKeySorting = this.manager.isKeySorting;
+            var ignoreTransition = event.ignoreTransition;
+            var offset = getPosition(event);
+            var translate = {
+              x: offset.x - this.initialOffset.x,
+              y: offset.y - this.initialOffset.y,
+            };
+            translate.y -= window.pageYOffset - this.initialWindowScroll.top;
+            translate.x -= window.pageXOffset - this.initialWindowScroll.left;
+            this.translate = translate;
+
+            if (lockToContainerEdges) {
+              var _getLockPixelOffsets = getLockPixelOffsets({
+                  height: this.height,
+                  lockOffset: lockOffset,
+                  width: this.width,
+                }),
+                _getLockPixelOffsets2 = _slicedToArray(_getLockPixelOffsets, 2),
+                minLockOffset = _getLockPixelOffsets2[0],
+                maxLockOffset = _getLockPixelOffsets2[1];
+
+              var minOffset = {
+                x: this.width / 2 - minLockOffset.x,
+                y: this.height / 2 - minLockOffset.y,
+              };
+              var maxOffset = {
+                x: this.width / 2 - maxLockOffset.x,
+                y: this.height / 2 - maxLockOffset.y,
+              };
+              translate.x = limit(
+                this.minTranslate.x + minOffset.x,
+                this.maxTranslate.x - maxOffset.x,
+                translate.x,
+              );
+              translate.y = limit(
+                this.minTranslate.y + minOffset.y,
+                this.maxTranslate.y - maxOffset.y,
+                translate.y,
+              );
+            }
+
+            if (lockAxis === 'x') {
+              translate.y = 0;
+            } else if (lockAxis === 'y') {
+              translate.x = 0;
+            }
+
+            if (
+              isKeySorting &&
+              keyboardSortingTransitionDuration &&
+              !ignoreTransition
+            ) {
+              setTransitionDuration(
+                this.helper,
+                keyboardSortingTransitionDuration,
+              );
+            }
+
+            setTranslate3d(this.helper, translate);
+          },
+        },
+        {
+          key: 'animateNodes',
+          value: function animateNodes() {
+            var _this$props7 = this.props,
+              transitionDuration = _this$props7.transitionDuration,
+              hideSortableGhost = _this$props7.hideSortableGhost,
+              onSortOver = _this$props7.onSortOver;
+            var containerScrollDelta = this.containerScrollDelta,
+              windowScrollDelta = this.windowScrollDelta;
+            var nodes = this.manager.getOrderedRefs();
+            var sortingOffset = {
+              left:
+                this.offsetEdge.left +
+                this.translate.x +
+                containerScrollDelta.left,
+              top:
+                this.offsetEdge.top +
+                this.translate.y +
+                containerScrollDelta.top,
+            };
+            var isKeySorting = this.manager.isKeySorting;
+            var prevIndex = this.newIndex;
+            this.newIndex = null;
+
+            for (var i = 0, len = nodes.length; i < len; i++) {
+              var _node3 = nodes[i].node;
+              var index = _node3.sortableInfo.index;
+              var width = _node3.offsetWidth;
+              var height = _node3.offsetHeight;
+              var offset = {
+                height: this.height > height ? height / 2 : this.height / 2,
+                width: this.width > width ? width / 2 : this.width / 2,
+              };
+              var mustShiftBackward =
+                isKeySorting && index > this.index && index <= prevIndex;
+              var mustShiftForward =
+                isKeySorting && index < this.index && index >= prevIndex;
+              var translate = {
+                x: 0,
+                y: 0,
+              };
+              var edgeOffset = nodes[i].edgeOffset;
+
+              if (!edgeOffset) {
+                edgeOffset = getEdgeOffset(_node3, this.container);
+                nodes[i].edgeOffset = edgeOffset;
+
+                if (isKeySorting) {
+                  nodes[
+                    i
+                  ].boundingClientRect = getScrollAdjustedBoundingClientRect(
+                    _node3,
+                    containerScrollDelta,
+                  );
+                }
+              }
+
+              var nextNode = i < nodes.length - 1 && nodes[i + 1];
+              var prevNode = i > 0 && nodes[i - 1];
+
+              if (nextNode && !nextNode.edgeOffset) {
+                nextNode.edgeOffset = getEdgeOffset(
+                  nextNode.node,
+                  this.container,
+                );
+
+                if (isKeySorting) {
+                  nextNode.boundingClientRect = getScrollAdjustedBoundingClientRect(
+                    nextNode.node,
+                    containerScrollDelta,
+                  );
+                }
+              }
+
+              if (index === this.index) {
+                if (hideSortableGhost) {
+                  this.sortableGhost = _node3;
+                  setInlineStyles(_node3, {
+                    opacity: 0,
+                    visibility: 'hidden',
+                  });
+                }
+
+                continue;
+              }
+
+              if (transitionDuration) {
+                setTransitionDuration(_node3, transitionDuration);
+              }
+
+              if (this.axis.x) {
+                if (this.axis.y) {
+                  if (
+                    mustShiftForward ||
+                    (index < this.index &&
+                      ((sortingOffset.left +
+                        windowScrollDelta.left -
+                        offset.width <=
+                        edgeOffset.left &&
+                        sortingOffset.top + windowScrollDelta.top <=
+                          edgeOffset.top + offset.height) ||
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height <=
+                          edgeOffset.top))
+                  ) {
+                    translate.x = this.width + this.marginOffset.x;
+
+                    if (
+                      edgeOffset.left + translate.x >
+                      this.containerBoundingRect.width - offset.width
+                    ) {
+                      if (nextNode) {
+                        translate.x =
+                          nextNode.edgeOffset.left - edgeOffset.left;
+                        translate.y = nextNode.edgeOffset.top - edgeOffset.top;
+                      }
+                    }
+
+                    if (this.newIndex === null) {
+                      this.newIndex = index;
+                    }
+                  } else if (
+                    mustShiftBackward ||
+                    (index > this.index &&
+                      ((sortingOffset.left +
+                        windowScrollDelta.left +
+                        offset.width >=
+                        edgeOffset.left &&
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height >=
+                          edgeOffset.top) ||
+                        sortingOffset.top +
+                          windowScrollDelta.top +
+                          offset.height >=
+                          edgeOffset.top + height))
+                  ) {
+                    translate.x = -(this.width + this.marginOffset.x);
+
+                    if (
+                      edgeOffset.left + translate.x <
+                      this.containerBoundingRect.left + offset.width
+                    ) {
+                      if (prevNode) {
+                        translate.x =
+                          prevNode.edgeOffset.left - edgeOffset.left;
+                        translate.y = prevNode.edgeOffset.top - edgeOffset.top;
+                      }
+                    }
+
+                    this.newIndex = index;
+                  }
+                } else {
+                  if (
+                    mustShiftBackward ||
+                    (index > this.index &&
+                      sortingOffset.left +
+                        windowScrollDelta.left +
+                        offset.width >=
+                        edgeOffset.left)
+                  ) {
+                    translate.x = -(this.width + this.marginOffset.x);
+                    this.newIndex = index;
+                  } else if (
+                    mustShiftForward ||
+                    (index < this.index &&
+                      sortingOffset.left + windowScrollDelta.left <=
+                        edgeOffset.left + offset.width)
+                  ) {
+                    translate.x = this.width + this.marginOffset.x;
+
+                    if (this.newIndex == null) {
+                      this.newIndex = index;
+                    }
+                  }
+                }
+              } else if (this.axis.y) {
+                if (
+                  mustShiftBackward ||
+                  (index > this.index &&
+                    sortingOffset.top + windowScrollDelta.top + offset.height >=
+                      edgeOffset.top)
+                ) {
+                  translate.y = -(this.height + this.marginOffset.y);
+                  this.newIndex = index;
+                } else if (
+                  mustShiftForward ||
+                  (index < this.index &&
+                    sortingOffset.top + windowScrollDelta.top <=
+                      edgeOffset.top + offset.height)
+                ) {
+                  translate.y = this.height + this.marginOffset.y;
+
+                  if (this.newIndex == null) {
+                    this.newIndex = index;
+                  }
+                }
+              }
+
+              setTranslate3d(_node3, translate);
+              nodes[i].translate = translate;
+            }
+
+            if (this.newIndex == null) {
+              this.newIndex = this.index;
+            }
+
+            if (isKeySorting) {
+              this.newIndex = prevIndex;
+            }
+
+            var oldIndex = isKeySorting ? this.prevIndex : prevIndex;
+
+            if (onSortOver && this.newIndex !== oldIndex) {
+              onSortOver({
+                collection: this.manager.active.collection,
+                index: this.index,
+                newIndex: this.newIndex,
+                oldIndex: oldIndex,
+                isKeySorting: isKeySorting,
+              });
+            }
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'getContainer',
+          value: function getContainer() {
+            var getContainer = this.props.getContainer;
+
+            if (typeof getContainer !== 'function') {
+              return reactDom.findDOMNode(this);
+            }
+
+            return getContainer(
+              config.withRef ? this.getWrappedInstance() : undefined,
+            );
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return React.createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                omit(this.props, omittedProps),
+              ),
+            );
+          },
+        },
+        {
+          key: 'helperContainer',
+          get: function get() {
+            var helperContainer = this.props.helperContainer;
+
+            if (typeof helperContainer === 'function') {
+              return helperContainer();
+            }
+
+            return this.props.helperContainer || this.document.body;
+          },
+        },
+        {
+          key: 'containerScrollDelta',
+          get: function get() {
+            var useWindowAsScrollContainer = this.props
+              .useWindowAsScrollContainer;
+
+            if (useWindowAsScrollContainer) {
+              return {
+                left: 0,
+                top: 0,
+              };
+            }
+
+            return {
+              left: this.scrollContainer.scrollLeft - this.initialScroll.left,
+              top: this.scrollContainer.scrollTop - this.initialScroll.top,
+            };
+          },
+        },
+        {
+          key: 'windowScrollDelta',
+          get: function get() {
+            return {
+              left:
+                this.contentWindow.pageXOffset - this.initialWindowScroll.left,
+              top:
+                this.contentWindow.pageYOffset - this.initialWindowScroll.top,
+            };
+          },
+        },
+      ]);
+
+      return WithSortableContainer;
+    })(React.Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableList', WrappedComponent),
+    ),
+    _defineProperty(_class, 'defaultProps', defaultProps),
+    _defineProperty(_class, 'propTypes', propTypes),
+    _defineProperty(_class, 'childContextTypes', {
+      manager: PropTypes.object.isRequired,
+    }),
+    _temp
+  );
+}
+
+var propTypes$1 = {
+  index: PropTypes.number.isRequired,
+  collection: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  disabled: PropTypes.bool,
+};
+var omittedProps$1 = Object.keys(propTypes$1);
+function sortableElement(WrappedComponent) {
+  var _class, _temp;
+
+  var config =
+    arguments.length > 1 && arguments[1] !== undefined
+      ? arguments[1]
+      : {
+          withRef: false,
+        };
+  return (
+    (_temp = _class = (function(_React$Component) {
+      _inherits(WithSortableElement, _React$Component);
+
+      function WithSortableElement() {
+        _classCallCheck(this, WithSortableElement);
+
+        return _possibleConstructorReturn(
+          this,
+          _getPrototypeOf(WithSortableElement).apply(this, arguments),
+        );
+      }
+
+      _createClass(WithSortableElement, [
+        {
+          key: 'componentDidMount',
+          value: function componentDidMount() {
+            this.register();
+          },
+        },
+        {
+          key: 'componentDidUpdate',
+          value: function componentDidUpdate(prevProps) {
+            if (this.node) {
+              if (prevProps.index !== this.props.index) {
+                this.node.sortableInfo.index = this.props.index;
+              }
+
+              if (prevProps.disabled !== this.props.disabled) {
+                this.node.sortableInfo.disabled = this.props.disabled;
+              }
+            }
+
+            if (prevProps.collection !== this.props.collection) {
+              this.unregister(prevProps.collection);
+              this.register();
+            }
+          },
+        },
+        {
+          key: 'componentWillUnmount',
+          value: function componentWillUnmount() {
+            this.unregister();
+          },
+        },
+        {
+          key: 'register',
+          value: function register() {
+            var _this$props = this.props,
+              collection = _this$props.collection,
+              disabled = _this$props.disabled,
+              index = _this$props.index;
+            var node = reactDom.findDOMNode(this);
+            node.sortableInfo = {
+              collection: collection,
+              disabled: disabled,
+              index: index,
+              manager: this.context.manager,
+            };
+            this.node = node;
+            this.ref = {
+              node: node,
+            };
+            this.context.manager.add(collection, this.ref);
+          },
+        },
+        {
+          key: 'unregister',
+          value: function unregister() {
+            var collection =
+              arguments.length > 0 && arguments[0] !== undefined
+                ? arguments[0]
+                : this.props.collection;
+            this.context.manager.remove(collection, this.ref);
+          },
+        },
+        {
+          key: 'getWrappedInstance',
+          value: function getWrappedInstance() {
+            invariant(
+              config.withRef,
+              'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableElement() call',
+            );
+            return this.refs.wrappedInstance;
+          },
+        },
+        {
+          key: 'render',
+          value: function render() {
+            var ref = config.withRef ? 'wrappedInstance' : null;
+            return React.createElement(
+              WrappedComponent,
+              _extends(
+                {
+                  ref: ref,
+                },
+                omit(this.props, omittedProps$1),
+              ),
+            );
+          },
+        },
+      ]);
+
+      return WithSortableElement;
+    })(React.Component)),
+    _defineProperty(
+      _class,
+      'displayName',
+      provideDisplayName('sortableElement', WrappedComponent),
+    ),
+    _defineProperty(_class, 'contextTypes', {
+      manager: PropTypes.object.isRequired,
+    }),
+    _defineProperty(_class, 'propTypes', propTypes$1),
+    _defineProperty(_class, 'defaultProps', {
+      collection: 0,
+    }),
+    _temp
+  );
+}
+
+exports.SortableContainer = sortableContainer;
+exports.sortableContainer = sortableContainer;
+exports.SortableElement = sortableElement;
+exports.sortableElement = sortableElement;
+exports.SortableHandle = sortableHandle;
+exports.sortableHandle = sortableHandle;
+exports.arrayMove = arrayMove;

--- a/dist/react-sortable-hoc.umd.js
+++ b/dist/react-sortable-hoc.umd.js
@@ -1,0 +1,2464 @@
+(function(global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined'
+    ? factory(
+        exports,
+        require('react'),
+        require('prop-types'),
+        require('react-dom'),
+      )
+    : typeof define === 'function' && define.amd
+    ? define(['exports', 'react', 'prop-types', 'react-dom'], factory)
+    : ((global = global || self),
+      factory(
+        (global.SortableHOC = {}),
+        global.React,
+        global.PropTypes,
+        global.ReactDOM,
+      ));
+})(this, function(exports, React, PropTypes, reactDom) {
+  'use strict';
+
+  PropTypes =
+    PropTypes && PropTypes.hasOwnProperty('default')
+      ? PropTypes['default']
+      : PropTypes;
+
+  function createCommonjsModule(fn, module) {
+    return (module = {exports: {}}), fn(module, module.exports), module.exports;
+  }
+
+  var _extends_1 = createCommonjsModule(function(module) {
+    function _extends() {
+      module.exports = _extends =
+        Object.assign ||
+        function(target) {
+          for (var i = 1; i < arguments.length; i++) {
+            var source = arguments[i];
+
+            for (var key in source) {
+              if (Object.prototype.hasOwnProperty.call(source, key)) {
+                target[key] = source[key];
+              }
+            }
+          }
+
+          return target;
+        };
+
+      return _extends.apply(this, arguments);
+    }
+
+    module.exports = _extends;
+  });
+
+  function _arrayWithHoles(arr) {
+    if (Array.isArray(arr)) return arr;
+  }
+
+  var arrayWithHoles = _arrayWithHoles;
+
+  function _iterableToArrayLimit(arr, i) {
+    var _arr = [];
+    var _n = true;
+    var _d = false;
+    var _e = undefined;
+
+    try {
+      for (
+        var _i = arr[Symbol.iterator](), _s;
+        !(_n = (_s = _i.next()).done);
+        _n = true
+      ) {
+        _arr.push(_s.value);
+
+        if (i && _arr.length === i) break;
+      }
+    } catch (err) {
+      _d = true;
+      _e = err;
+    } finally {
+      try {
+        if (!_n && _i['return'] != null) _i['return']();
+      } finally {
+        if (_d) throw _e;
+      }
+    }
+
+    return _arr;
+  }
+
+  var iterableToArrayLimit = _iterableToArrayLimit;
+
+  function _nonIterableRest() {
+    throw new TypeError('Invalid attempt to destructure non-iterable instance');
+  }
+
+  var nonIterableRest = _nonIterableRest;
+
+  function _slicedToArray(arr, i) {
+    return (
+      arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || nonIterableRest()
+    );
+  }
+
+  var slicedToArray = _slicedToArray;
+
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      obj[key] = value;
+    }
+
+    return obj;
+  }
+
+  var defineProperty = _defineProperty;
+
+  function _objectSpread(target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i] != null ? arguments[i] : {};
+      var ownKeys = Object.keys(source);
+
+      if (typeof Object.getOwnPropertySymbols === 'function') {
+        ownKeys = ownKeys.concat(
+          Object.getOwnPropertySymbols(source).filter(function(sym) {
+            return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+          }),
+        );
+      }
+
+      ownKeys.forEach(function(key) {
+        defineProperty(target, key, source[key]);
+      });
+    }
+
+    return target;
+  }
+
+  var objectSpread = _objectSpread;
+
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError('Cannot call a class as a function');
+    }
+  }
+
+  var classCallCheck = _classCallCheck;
+
+  function _defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ('value' in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+
+  function _createClass(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+  }
+
+  var createClass = _createClass;
+
+  var _typeof_1 = createCommonjsModule(function(module) {
+    function _typeof2(obj) {
+      if (typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol') {
+        _typeof2 = function _typeof2(obj) {
+          return typeof obj;
+        };
+      } else {
+        _typeof2 = function _typeof2(obj) {
+          return obj &&
+            typeof Symbol === 'function' &&
+            obj.constructor === Symbol &&
+            obj !== Symbol.prototype
+            ? 'symbol'
+            : typeof obj;
+        };
+      }
+      return _typeof2(obj);
+    }
+
+    function _typeof(obj) {
+      if (
+        typeof Symbol === 'function' &&
+        _typeof2(Symbol.iterator) === 'symbol'
+      ) {
+        module.exports = _typeof = function _typeof(obj) {
+          return _typeof2(obj);
+        };
+      } else {
+        module.exports = _typeof = function _typeof(obj) {
+          return obj &&
+            typeof Symbol === 'function' &&
+            obj.constructor === Symbol &&
+            obj !== Symbol.prototype
+            ? 'symbol'
+            : _typeof2(obj);
+        };
+      }
+
+      return _typeof(obj);
+    }
+
+    module.exports = _typeof;
+  });
+
+  function _assertThisInitialized(self) {
+    if (self === void 0) {
+      throw new ReferenceError(
+        "this hasn't been initialised - super() hasn't been called",
+      );
+    }
+
+    return self;
+  }
+
+  var assertThisInitialized = _assertThisInitialized;
+
+  function _possibleConstructorReturn(self, call) {
+    if (call && (_typeof_1(call) === 'object' || typeof call === 'function')) {
+      return call;
+    }
+
+    return assertThisInitialized(self);
+  }
+
+  var possibleConstructorReturn = _possibleConstructorReturn;
+
+  var getPrototypeOf = createCommonjsModule(function(module) {
+    function _getPrototypeOf(o) {
+      module.exports = _getPrototypeOf = Object.setPrototypeOf
+        ? Object.getPrototypeOf
+        : function _getPrototypeOf(o) {
+            return o.__proto__ || Object.getPrototypeOf(o);
+          };
+      return _getPrototypeOf(o);
+    }
+
+    module.exports = _getPrototypeOf;
+  });
+
+  var setPrototypeOf = createCommonjsModule(function(module) {
+    function _setPrototypeOf(o, p) {
+      module.exports = _setPrototypeOf =
+        Object.setPrototypeOf ||
+        function _setPrototypeOf(o, p) {
+          o.__proto__ = p;
+          return o;
+        };
+
+      return _setPrototypeOf(o, p);
+    }
+
+    module.exports = _setPrototypeOf;
+  });
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== 'function' && superClass !== null) {
+      throw new TypeError('Super expression must either be null or a function');
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        writable: true,
+        configurable: true,
+      },
+    });
+    if (superClass) setPrototypeOf(subClass, superClass);
+  }
+
+  var inherits = _inherits;
+
+  /**
+   * Copyright (c) 2013-present, Facebook, Inc.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+
+  var invariant = function(condition, format, a, b, c, d, e, f) {
+    {
+      if (format === undefined) {
+        throw new Error('invariant requires an error message argument');
+      }
+    }
+
+    if (!condition) {
+      var error;
+      if (format === undefined) {
+        error = new Error(
+          'Minified exception occurred; use the non-minified dev environment ' +
+            'for the full error message and additional helpful warnings.',
+        );
+      } else {
+        var args = [a, b, c, d, e, f];
+        var argIndex = 0;
+        error = new Error(
+          format.replace(/%s/g, function() {
+            return args[argIndex++];
+          }),
+        );
+        error.name = 'Invariant Violation';
+      }
+
+      error.framesToPop = 1; // we don't care about invariant's own frame
+      throw error;
+    }
+  };
+
+  var invariant_1 = invariant;
+
+  var Manager = (function() {
+    function Manager() {
+      classCallCheck(this, Manager);
+
+      defineProperty(this, 'refs', {});
+    }
+
+    createClass(Manager, [
+      {
+        key: 'add',
+        value: function add(collection, ref) {
+          if (!this.refs[collection]) {
+            this.refs[collection] = [];
+          }
+
+          this.refs[collection].push(ref);
+        },
+      },
+      {
+        key: 'remove',
+        value: function remove(collection, ref) {
+          var index = this.getIndex(collection, ref);
+
+          if (index !== -1) {
+            this.refs[collection].splice(index, 1);
+          }
+        },
+      },
+      {
+        key: 'isActive',
+        value: function isActive() {
+          return this.active;
+        },
+      },
+      {
+        key: 'getActive',
+        value: function getActive() {
+          var _this = this;
+
+          return this.refs[this.active.collection].find(function(_ref) {
+            var node = _ref.node;
+            return node.sortableInfo.index == _this.active.index;
+          });
+        },
+      },
+      {
+        key: 'getIndex',
+        value: function getIndex(collection, ref) {
+          return this.refs[collection].indexOf(ref);
+        },
+      },
+      {
+        key: 'getOrderedRefs',
+        value: function getOrderedRefs() {
+          var collection =
+            arguments.length > 0 && arguments[0] !== undefined
+              ? arguments[0]
+              : this.active.collection;
+          return this.refs[collection].sort(sortByIndex);
+        },
+      },
+    ]);
+
+    return Manager;
+  })();
+
+  function sortByIndex(_ref2, _ref3) {
+    var index1 = _ref2.node.sortableInfo.index;
+    var index2 = _ref3.node.sortableInfo.index;
+    return index1 - index2;
+  }
+
+  function _arrayWithoutHoles(arr) {
+    if (Array.isArray(arr)) {
+      for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) {
+        arr2[i] = arr[i];
+      }
+
+      return arr2;
+    }
+  }
+
+  var arrayWithoutHoles = _arrayWithoutHoles;
+
+  function _iterableToArray(iter) {
+    if (
+      Symbol.iterator in Object(iter) ||
+      Object.prototype.toString.call(iter) === '[object Arguments]'
+    )
+      return Array.from(iter);
+  }
+
+  var iterableToArray = _iterableToArray;
+
+  function _nonIterableSpread() {
+    throw new TypeError('Invalid attempt to spread non-iterable instance');
+  }
+
+  var nonIterableSpread = _nonIterableSpread;
+
+  function _toConsumableArray(arr) {
+    return (
+      arrayWithoutHoles(arr) || iterableToArray(arr) || nonIterableSpread()
+    );
+  }
+
+  var toConsumableArray = _toConsumableArray;
+
+  function arrayMove(array, from, to) {
+    {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          "Deprecation warning: arrayMove will no longer be exported by 'react-sortable-hoc' in the next major release. Please install the `array-move` package locally instead. https://www.npmjs.com/package/array-move",
+        );
+      }
+    }
+
+    array = array.slice();
+    array.splice(to < 0 ? array.length + to : to, 0, array.splice(from, 1)[0]);
+    return array;
+  }
+  function omit(obj, keysToOmit) {
+    return Object.keys(obj).reduce(function(acc, key) {
+      if (keysToOmit.indexOf(key) === -1) {
+        acc[key] = obj[key];
+      }
+
+      return acc;
+    }, {});
+  }
+  var events = {
+    end: ['touchend', 'touchcancel', 'mouseup'],
+    move: ['touchmove', 'mousemove'],
+    start: ['touchstart', 'mousedown'],
+  };
+  var vendorPrefix = (function() {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return '';
+    }
+
+    var styles = window.getComputedStyle(document.documentElement, '') || [
+      '-moz-hidden-iframe',
+    ];
+    var pre = (Array.prototype.slice
+      .call(styles)
+      .join('')
+      .match(/-(moz|webkit|ms)-/) ||
+      (styles.OLink === '' && ['', 'o']))[1];
+
+    switch (pre) {
+      case 'ms':
+        return 'ms';
+
+      default:
+        return pre && pre.length ? pre[0].toUpperCase() + pre.substr(1) : '';
+    }
+  })();
+  function setInlineStyles(node, styles) {
+    Object.keys(styles).forEach(function(key) {
+      node.style[key] = styles[key];
+    });
+  }
+  function setTranslate3d(node, translate) {
+    node.style[''.concat(vendorPrefix, 'Transform')] =
+      translate == null
+        ? ''
+        : 'translate3d('
+            .concat(translate.x, 'px,')
+            .concat(translate.y, 'px,0)');
+  }
+  function setTransitionDuration(node, duration) {
+    node.style[''.concat(vendorPrefix, 'TransitionDuration')] =
+      duration == null ? '' : ''.concat(duration, 'ms');
+  }
+  function closest(el, fn) {
+    while (el) {
+      if (fn(el)) {
+        return el;
+      }
+
+      el = el.parentNode;
+    }
+
+    return null;
+  }
+  function limit(min, max, value) {
+    return Math.max(min, Math.min(value, max));
+  }
+
+  function getPixelValue(stringValue) {
+    if (stringValue.substr(-2) === 'px') {
+      return parseFloat(stringValue);
+    }
+
+    return 0;
+  }
+
+  function getElementMargin(element) {
+    var style = window.getComputedStyle(element);
+    return {
+      bottom: getPixelValue(style.marginBottom),
+      left: getPixelValue(style.marginLeft),
+      right: getPixelValue(style.marginRight),
+      top: getPixelValue(style.marginTop),
+    };
+  }
+  function provideDisplayName(prefix, Component) {
+    var componentName = Component.displayName || Component.name;
+    return componentName
+      ? ''.concat(prefix, '(').concat(componentName, ')')
+      : prefix;
+  }
+  function getScrollAdjustedBoundingClientRect(node, scrollDelta) {
+    var boundingClientRect = node.getBoundingClientRect();
+    return {
+      top: boundingClientRect.top + scrollDelta.top,
+      left: boundingClientRect.left + scrollDelta.left,
+    };
+  }
+  function getPosition(event) {
+    if (event.touches && event.touches.length) {
+      return {
+        x: event.touches[0].pageX,
+        y: event.touches[0].pageY,
+      };
+    } else if (event.changedTouches && event.changedTouches.length) {
+      return {
+        x: event.changedTouches[0].pageX,
+        y: event.changedTouches[0].pageY,
+      };
+    } else {
+      return {
+        x: event.pageX,
+        y: event.pageY,
+      };
+    }
+  }
+  function isTouchEvent(event) {
+    return (
+      (event.touches && event.touches.length) ||
+      (event.changedTouches && event.changedTouches.length)
+    );
+  }
+  function getEdgeOffset(node, parent) {
+    var offset =
+      arguments.length > 2 && arguments[2] !== undefined
+        ? arguments[2]
+        : {
+            left: 0,
+            top: 0,
+          };
+
+    if (!node) {
+      return undefined;
+    }
+
+    var nodeOffset = {
+      left: offset.left + node.offsetLeft,
+      top: offset.top + node.offsetTop,
+    };
+
+    if (node.parentNode === parent) {
+      return nodeOffset;
+    }
+
+    return getEdgeOffset(node.parentNode, parent, nodeOffset);
+  }
+  function getTargetIndex(newIndex, prevIndex, oldIndex) {
+    if (newIndex < oldIndex && newIndex > prevIndex) {
+      return newIndex - 1;
+    } else if (newIndex > oldIndex && newIndex < prevIndex) {
+      return newIndex + 1;
+    } else {
+      return newIndex;
+    }
+  }
+  function getLockPixelOffset(_ref) {
+    var lockOffset = _ref.lockOffset,
+      width = _ref.width,
+      height = _ref.height;
+    var offsetX = lockOffset;
+    var offsetY = lockOffset;
+    var unit = 'px';
+
+    if (typeof lockOffset === 'string') {
+      var match = /^[+-]?\d*(?:\.\d*)?(px|%)$/.exec(lockOffset);
+      invariant_1(
+        match !== null,
+        'lockOffset value should be a number or a string of a ' +
+          'number followed by "px" or "%". Given %s',
+        lockOffset,
+      );
+      offsetX = parseFloat(lockOffset);
+      offsetY = parseFloat(lockOffset);
+      unit = match[1];
+    }
+
+    invariant_1(
+      isFinite(offsetX) && isFinite(offsetY),
+      'lockOffset value should be a finite. Given %s',
+      lockOffset,
+    );
+
+    if (unit === '%') {
+      offsetX = (offsetX * width) / 100;
+      offsetY = (offsetY * height) / 100;
+    }
+
+    return {
+      x: offsetX,
+      y: offsetY,
+    };
+  }
+  function getLockPixelOffsets(_ref2) {
+    var height = _ref2.height,
+      width = _ref2.width,
+      lockOffset = _ref2.lockOffset;
+    var offsets = Array.isArray(lockOffset)
+      ? lockOffset
+      : [lockOffset, lockOffset];
+    invariant_1(
+      offsets.length === 2,
+      'lockOffset prop of SortableContainer should be a single ' +
+        'value or an array of exactly two values. Given %s',
+      lockOffset,
+    );
+
+    var _offsets = slicedToArray(offsets, 2),
+      minLockOffset = _offsets[0],
+      maxLockOffset = _offsets[1];
+
+    return [
+      getLockPixelOffset({
+        height: height,
+        lockOffset: minLockOffset,
+        width: width,
+      }),
+      getLockPixelOffset({
+        height: height,
+        lockOffset: maxLockOffset,
+        width: width,
+      }),
+    ];
+  }
+
+  function isScrollable(el) {
+    var computedStyle = window.getComputedStyle(el);
+    var overflowRegex = /(auto|scroll)/;
+    var properties = ['overflow', 'overflowX', 'overflowY'];
+    return properties.find(function(property) {
+      return overflowRegex.test(computedStyle[property]);
+    });
+  }
+
+  function getScrollingParent(el) {
+    if (!(el instanceof HTMLElement)) {
+      return null;
+    } else if (isScrollable(el)) {
+      return el;
+    } else {
+      return getScrollingParent(el.parentNode);
+    }
+  }
+  var KEYCODE = {
+    TAB: 9,
+    ESC: 27,
+    SPACE: 32,
+    LEFT: 37,
+    UP: 38,
+    RIGHT: 39,
+    DOWN: 40,
+  };
+  var NodeType = {
+    Anchor: 'A',
+    Button: 'BUTTON',
+    Canvas: 'CANVAS',
+    Input: 'INPUT',
+    Option: 'OPTION',
+    Textarea: 'TEXTAREA',
+    Select: 'SELECT',
+  };
+  function cloneNode(node) {
+    var selector = 'input, textarea, select, canvas, [contenteditable]';
+    var fields = node.querySelectorAll(selector);
+    var clonedNode = node.cloneNode(true);
+
+    var clonedFields = toConsumableArray(clonedNode.querySelectorAll(selector));
+
+    clonedFields.forEach(function(field, i) {
+      if (field.type !== 'file') {
+        field.value = fields[i].value;
+      }
+
+      if (field.type === 'radio' && field.name) {
+        field.name = '__sortableClone__'.concat(field.name);
+      }
+
+      if (
+        field.tagName === NodeType.Canvas &&
+        fields[i].width > 0 &&
+        fields[i].height > 0
+      ) {
+        var destCtx = field.getContext('2d');
+        destCtx.drawImage(fields[i], 0, 0);
+      }
+    });
+    return clonedNode;
+  }
+
+  function sortableHandle(WrappedComponent) {
+    var _class, _temp;
+
+    var config =
+      arguments.length > 1 && arguments[1] !== undefined
+        ? arguments[1]
+        : {
+            withRef: false,
+          };
+    return (
+      (_temp = _class = (function(_React$Component) {
+        inherits(WithSortableHandle, _React$Component);
+
+        function WithSortableHandle() {
+          classCallCheck(this, WithSortableHandle);
+
+          return possibleConstructorReturn(
+            this,
+            getPrototypeOf(WithSortableHandle).apply(this, arguments),
+          );
+        }
+
+        createClass(WithSortableHandle, [
+          {
+            key: 'componentDidMount',
+            value: function componentDidMount() {
+              var node = reactDom.findDOMNode(this);
+              node.sortableHandle = true;
+            },
+          },
+          {
+            key: 'getWrappedInstance',
+            value: function getWrappedInstance() {
+              invariant_1(
+                config.withRef,
+                'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableHandle() call',
+              );
+              return this.refs.wrappedInstance;
+            },
+          },
+          {
+            key: 'render',
+            value: function render() {
+              var ref = config.withRef ? 'wrappedInstance' : null;
+              return React.createElement(
+                WrappedComponent,
+                _extends_1(
+                  {
+                    ref: ref,
+                  },
+                  this.props,
+                ),
+              );
+            },
+          },
+        ]);
+
+        return WithSortableHandle;
+      })(React.Component)),
+      defineProperty(
+        _class,
+        'displayName',
+        provideDisplayName('sortableHandle', WrappedComponent),
+      ),
+      _temp
+    );
+  }
+  function isSortableHandle(node) {
+    return node.sortableHandle != null;
+  }
+
+  var AutoScroller = (function() {
+    function AutoScroller(container, onScrollCallback) {
+      classCallCheck(this, AutoScroller);
+
+      this.container = container;
+      this.onScrollCallback = onScrollCallback;
+    }
+
+    createClass(AutoScroller, [
+      {
+        key: 'clear',
+        value: function clear() {
+          if (this.interval == null) {
+            return;
+          }
+
+          clearInterval(this.interval);
+          this.interval = null;
+        },
+      },
+      {
+        key: 'update',
+        value: function update(_ref) {
+          var _this = this;
+
+          var translate = _ref.translate,
+            minTranslate = _ref.minTranslate,
+            maxTranslate = _ref.maxTranslate,
+            width = _ref.width,
+            height = _ref.height;
+          var direction = {
+            x: 0,
+            y: 0,
+          };
+          var speed = {
+            x: 1,
+            y: 1,
+          };
+          var acceleration = {
+            x: 10,
+            y: 10,
+          };
+          var _this$container = this.container,
+            scrollTop = _this$container.scrollTop,
+            scrollLeft = _this$container.scrollLeft,
+            scrollHeight = _this$container.scrollHeight,
+            scrollWidth = _this$container.scrollWidth,
+            clientHeight = _this$container.clientHeight,
+            clientWidth = _this$container.clientWidth;
+          var isTop = scrollTop === 0;
+          var isBottom = scrollHeight - scrollTop - clientHeight === 0;
+          var isLeft = scrollLeft === 0;
+          var isRight = scrollWidth - scrollLeft - clientWidth === 0;
+
+          if (translate.y >= maxTranslate.y - height / 2 && !isBottom) {
+            direction.y = 1;
+            speed.y =
+              acceleration.y *
+              Math.abs((maxTranslate.y - height / 2 - translate.y) / height);
+          } else if (translate.x >= maxTranslate.x - width / 2 && !isRight) {
+            direction.x = 1;
+            speed.x =
+              acceleration.x *
+              Math.abs((maxTranslate.x - width / 2 - translate.x) / width);
+          } else if (translate.y <= minTranslate.y + height / 2 && !isTop) {
+            direction.y = -1;
+            speed.y =
+              acceleration.y *
+              Math.abs((translate.y - height / 2 - minTranslate.y) / height);
+          } else if (translate.x <= minTranslate.x + width / 2 && !isLeft) {
+            direction.x = -1;
+            speed.x =
+              acceleration.x *
+              Math.abs((translate.x - width / 2 - minTranslate.x) / width);
+          }
+
+          if (this.interval) {
+            this.clear();
+            this.isAutoScrolling = false;
+          }
+
+          if (direction.x !== 0 || direction.y !== 0) {
+            this.interval = setInterval(function() {
+              _this.isAutoScrolling = true;
+              var offset = {
+                left: speed.x * direction.x,
+                top: speed.y * direction.y,
+              };
+              _this.container.scrollTop += offset.top;
+              _this.container.scrollLeft += offset.left;
+
+              _this.onScrollCallback(offset);
+            }, 5);
+          }
+        },
+      },
+    ]);
+
+    return AutoScroller;
+  })();
+
+  function defaultGetHelperDimensions(_ref) {
+    var node = _ref.node;
+    return {
+      height: node.offsetHeight,
+      width: node.offsetWidth,
+    };
+  }
+
+  function defaultShouldCancelStart(event) {
+    var interactiveElements = [
+      NodeType.Input,
+      NodeType.Textarea,
+      NodeType.Select,
+      NodeType.Option,
+      NodeType.Button,
+    ];
+
+    if (interactiveElements.indexOf(event.target.tagName) !== -1) {
+      return true;
+    }
+
+    if (
+      closest(event.target, function(el) {
+        return el.contentEditable === 'true';
+      })
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  var propTypes = {
+    axis: PropTypes.oneOf(['x', 'y', 'xy']),
+    contentWindow: PropTypes.any,
+    disableAutoscroll: PropTypes.bool,
+    distance: PropTypes.number,
+    getContainer: PropTypes.func,
+    getHelperDimensions: PropTypes.func,
+    helperClass: PropTypes.string,
+    helperContainer: PropTypes.oneOfType([
+      PropTypes.func,
+      typeof HTMLElement === 'undefined'
+        ? PropTypes.any
+        : PropTypes.instanceOf(HTMLElement),
+    ]),
+    hideSortableGhost: PropTypes.bool,
+    keyboardSortingTransitionDuration: PropTypes.number,
+    lockAxis: PropTypes.string,
+    lockOffset: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      ),
+    ]),
+    lockToContainerEdges: PropTypes.bool,
+    onSortEnd: PropTypes.func,
+    onSortMove: PropTypes.func,
+    onSortOver: PropTypes.func,
+    onSortStart: PropTypes.func,
+    pressDelay: PropTypes.number,
+    pressThreshold: PropTypes.number,
+    keyCodes: PropTypes.shape({
+      lift: PropTypes.arrayOf(PropTypes.number),
+      drop: PropTypes.arrayOf(PropTypes.number),
+      cancel: PropTypes.arrayOf(PropTypes.number),
+      up: PropTypes.arrayOf(PropTypes.number),
+      down: PropTypes.arrayOf(PropTypes.number),
+    }),
+    shouldCancelStart: PropTypes.func,
+    transitionDuration: PropTypes.number,
+    updateBeforeSortStart: PropTypes.func,
+    useDragHandle: PropTypes.bool,
+    useWindowAsScrollContainer: PropTypes.bool,
+  };
+  var defaultKeyCodes = {
+    lift: [KEYCODE.SPACE],
+    drop: [KEYCODE.SPACE],
+    cancel: [KEYCODE.ESC],
+    up: [KEYCODE.UP, KEYCODE.LEFT],
+    down: [KEYCODE.DOWN, KEYCODE.RIGHT],
+  };
+  var defaultProps = {
+    axis: 'y',
+    disableAutoscroll: false,
+    distance: 0,
+    getHelperDimensions: defaultGetHelperDimensions,
+    hideSortableGhost: true,
+    lockOffset: '50%',
+    lockToContainerEdges: false,
+    pressDelay: 0,
+    pressThreshold: 5,
+    keyCodes: defaultKeyCodes,
+    shouldCancelStart: defaultShouldCancelStart,
+    transitionDuration: 300,
+    useWindowAsScrollContainer: false,
+  };
+  var omittedProps = Object.keys(propTypes);
+  function validateProps(props) {
+    invariant_1(
+      !(props.distance && props.pressDelay),
+      'Attempted to set both `pressDelay` and `distance` on SortableContainer, you may only use one or the other, not both at the same time.',
+    );
+  }
+
+  function _finallyRethrows(body, finalizer) {
+    try {
+      var result = body();
+    } catch (e) {
+      return finalizer(true, e);
+    }
+
+    if (result && result.then) {
+      return result.then(
+        finalizer.bind(null, false),
+        finalizer.bind(null, true),
+      );
+    }
+
+    return finalizer(false, value);
+  }
+  function sortableContainer(WrappedComponent) {
+    var _class, _temp;
+
+    var config =
+      arguments.length > 1 && arguments[1] !== undefined
+        ? arguments[1]
+        : {
+            withRef: false,
+          };
+    return (
+      (_temp = _class = (function(_React$Component) {
+        inherits(WithSortableContainer, _React$Component);
+
+        function WithSortableContainer(props) {
+          var _this;
+
+          classCallCheck(this, WithSortableContainer);
+
+          _this = possibleConstructorReturn(
+            this,
+            getPrototypeOf(WithSortableContainer).call(this, props),
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'state',
+            {},
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleStart',
+            function(event) {
+              var _this$props = _this.props,
+                distance = _this$props.distance,
+                shouldCancelStart = _this$props.shouldCancelStart;
+
+              if (event.button === 2 || shouldCancelStart(event)) {
+                return;
+              }
+
+              _this.touched = true;
+              _this.position = getPosition(event);
+              var node = closest(event.target, function(el) {
+                return el.sortableInfo != null;
+              });
+
+              if (
+                node &&
+                node.sortableInfo &&
+                _this.nodeIsChild(node) &&
+                !_this.state.sorting
+              ) {
+                var useDragHandle = _this.props.useDragHandle;
+                var _node$sortableInfo = node.sortableInfo,
+                  index = _node$sortableInfo.index,
+                  collection = _node$sortableInfo.collection,
+                  disabled = _node$sortableInfo.disabled;
+
+                if (disabled) {
+                  return;
+                }
+
+                if (useDragHandle && !closest(event.target, isSortableHandle)) {
+                  return;
+                }
+
+                _this.manager.active = {
+                  collection: collection,
+                  index: index,
+                };
+
+                if (
+                  !isTouchEvent(event) &&
+                  event.target.tagName === NodeType.Anchor
+                ) {
+                  event.preventDefault();
+                }
+
+                if (!distance) {
+                  if (_this.props.pressDelay === 0) {
+                    _this.handlePress(event);
+                  } else {
+                    _this.pressTimer = setTimeout(function() {
+                      return _this.handlePress(event);
+                    }, _this.props.pressDelay);
+                  }
+                }
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'nodeIsChild',
+            function(node) {
+              return node.sortableInfo.manager === _this.manager;
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleMove',
+            function(event) {
+              var _this$props2 = _this.props,
+                distance = _this$props2.distance,
+                pressThreshold = _this$props2.pressThreshold;
+
+              if (
+                !_this.state.sorting &&
+                _this.touched &&
+                !_this._awaitingUpdateBeforeSortStart
+              ) {
+                var position = getPosition(event);
+                var delta = {
+                  x: _this.position.x - position.x,
+                  y: _this.position.y - position.y,
+                };
+                var combinedDelta = Math.abs(delta.x) + Math.abs(delta.y);
+                _this.delta = delta;
+
+                if (
+                  !distance &&
+                  (!pressThreshold || combinedDelta >= pressThreshold)
+                ) {
+                  clearTimeout(_this.cancelTimer);
+                  _this.cancelTimer = setTimeout(_this.cancel, 0);
+                } else if (
+                  distance &&
+                  combinedDelta >= distance &&
+                  _this.manager.isActive()
+                ) {
+                  _this.handlePress(event);
+                }
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleEnd',
+            function() {
+              _this.touched = false;
+
+              _this.cancel();
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'cancel',
+            function() {
+              var distance = _this.props.distance;
+              var sorting = _this.state.sorting;
+
+              if (!sorting) {
+                if (!distance) {
+                  clearTimeout(_this.pressTimer);
+                }
+
+                _this.manager.active = null;
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handlePress',
+            function(event) {
+              try {
+                var _exit2 = false;
+
+                var active = _this.manager.getActive();
+
+                return Promise.resolve(
+                  (function() {
+                    if (active) {
+                      var _temp4 = function _temp4(_result2) {
+                        if (_exit2) return _result2;
+                        var index = _node.sortableInfo.index;
+                        var margin = getElementMargin(_node);
+
+                        var containerBoundingRect = _this.scrollContainer.getBoundingClientRect();
+
+                        var dimensions = _getHelperDimensions({
+                          collection: _collection,
+                          index: index,
+                          node: _node,
+                        });
+
+                        _this.node = _node;
+                        _this.margin = margin;
+                        _this.width = dimensions.width;
+                        _this.height = dimensions.height;
+                        _this.marginOffset = {
+                          x: _this.margin.left + _this.margin.right,
+                          y: Math.max(_this.margin.top, _this.margin.bottom),
+                        };
+                        _this.boundingClientRect = _node.getBoundingClientRect();
+                        _this.containerBoundingRect = containerBoundingRect;
+                        _this.index = index;
+                        _this.newIndex = index;
+                        _this.axis = {
+                          x: _axis.indexOf('x') >= 0,
+                          y: _axis.indexOf('y') >= 0,
+                        };
+                        _this.offsetEdge = getEdgeOffset(
+                          _node,
+                          _this.container,
+                        );
+
+                        if (_isKeySorting) {
+                          _this.initialOffset = getPosition(
+                            objectSpread({}, event, {
+                              pageX: _this.boundingClientRect.left,
+                              pageY: _this.boundingClientRect.top,
+                            }),
+                          );
+                        } else {
+                          _this.initialOffset = getPosition(event);
+                        }
+
+                        _this.initialScroll = {
+                          left: _this.scrollContainer.scrollLeft,
+                          top: _this.scrollContainer.scrollTop,
+                        };
+                        _this.initialWindowScroll = {
+                          left: window.pageXOffset,
+                          top: window.pageYOffset,
+                        };
+                        _this.helper = _this.helperContainer.appendChild(
+                          cloneNode(_node),
+                        );
+                        setInlineStyles(_this.helper, {
+                          boxSizing: 'border-box',
+                          height: ''.concat(_this.height, 'px'),
+                          left: ''.concat(
+                            _this.boundingClientRect.left - margin.left,
+                            'px',
+                          ),
+                          pointerEvents: 'none',
+                          position: 'fixed',
+                          top: ''.concat(
+                            _this.boundingClientRect.top - margin.top,
+                            'px',
+                          ),
+                          width: ''.concat(_this.width, 'px'),
+                        });
+
+                        if (_isKeySorting) {
+                          _this.helper.focus();
+                        }
+
+                        if (_hideSortableGhost) {
+                          _this.sortableGhost = _node;
+                          setInlineStyles(_node, {
+                            opacity: 0,
+                            visibility: 'hidden',
+                          });
+                        }
+
+                        _this.minTranslate = {};
+                        _this.maxTranslate = {};
+
+                        if (_isKeySorting) {
+                          var _ref = _useWindowAsScrollContainer
+                              ? {
+                                  top: 0,
+                                  left: 0,
+                                  width: _this.contentWindow.innerWidth,
+                                  height: _this.contentWindow.innerHeight,
+                                }
+                              : _this.containerBoundingRect,
+                            containerTop = _ref.top,
+                            containerLeft = _ref.left,
+                            containerWidth = _ref.width,
+                            containerHeight = _ref.height;
+
+                          var containerBottom = containerTop + containerHeight;
+                          var containerRight = containerLeft + containerWidth;
+
+                          if (_this.axis.x) {
+                            _this.minTranslate.x =
+                              containerLeft - _this.boundingClientRect.left;
+                            _this.maxTranslate.x =
+                              containerRight -
+                              (_this.boundingClientRect.left + _this.width);
+                          }
+
+                          if (_this.axis.y) {
+                            _this.minTranslate.y =
+                              containerTop - _this.boundingClientRect.top;
+                            _this.maxTranslate.y =
+                              containerBottom -
+                              (_this.boundingClientRect.top + _this.height);
+                          }
+                        } else {
+                          if (_this.axis.x) {
+                            _this.minTranslate.x =
+                              (_useWindowAsScrollContainer
+                                ? 0
+                                : containerBoundingRect.left) -
+                              _this.boundingClientRect.left -
+                              _this.width / 2;
+                            _this.maxTranslate.x =
+                              (_useWindowAsScrollContainer
+                                ? _this.contentWindow.innerWidth
+                                : containerBoundingRect.left +
+                                  containerBoundingRect.width) -
+                              _this.boundingClientRect.left -
+                              _this.width / 2;
+                          }
+
+                          if (_this.axis.y) {
+                            _this.minTranslate.y =
+                              (_useWindowAsScrollContainer
+                                ? 0
+                                : containerBoundingRect.top) -
+                              _this.boundingClientRect.top -
+                              _this.height / 2;
+                            _this.maxTranslate.y =
+                              (_useWindowAsScrollContainer
+                                ? _this.contentWindow.innerHeight
+                                : containerBoundingRect.top +
+                                  containerBoundingRect.height) -
+                              _this.boundingClientRect.top -
+                              _this.height / 2;
+                          }
+                        }
+
+                        if (_helperClass) {
+                          _helperClass.split(' ').forEach(function(className) {
+                            return _this.helper.classList.add(className);
+                          });
+                        }
+
+                        _this.listenerNode = event.touches
+                          ? _node
+                          : _this.contentWindow;
+
+                        if (_isKeySorting) {
+                          _this.listenerNode.addEventListener(
+                            'wheel',
+                            _this.handleKeyEnd,
+                            true,
+                          );
+
+                          _this.listenerNode.addEventListener(
+                            'mousedown',
+                            _this.handleKeyEnd,
+                            true,
+                          );
+
+                          _this.listenerNode.addEventListener(
+                            'keydown',
+                            _this.handleKeyDown,
+                          );
+                        } else {
+                          events.move.forEach(function(eventName) {
+                            return _this.listenerNode.addEventListener(
+                              eventName,
+                              _this.handleSortMove,
+                              false,
+                            );
+                          });
+                          events.end.forEach(function(eventName) {
+                            return _this.listenerNode.addEventListener(
+                              eventName,
+                              _this.handleSortEnd,
+                              false,
+                            );
+                          });
+                        }
+
+                        _this.setState({
+                          sorting: true,
+                          sortingIndex: index,
+                        });
+
+                        if (_onSortStart) {
+                          _onSortStart(
+                            {
+                              node: _node,
+                              index: index,
+                              collection: _collection,
+                              isKeySorting: _isKeySorting,
+                            },
+                            event,
+                          );
+                        }
+
+                        if (_isKeySorting) {
+                          _this.keyMove(0);
+                        }
+                      };
+
+                      var _this$props3 = _this.props,
+                        _axis = _this$props3.axis,
+                        _getHelperDimensions = _this$props3.getHelperDimensions,
+                        _helperClass = _this$props3.helperClass,
+                        _hideSortableGhost = _this$props3.hideSortableGhost,
+                        updateBeforeSortStart =
+                          _this$props3.updateBeforeSortStart,
+                        _onSortStart = _this$props3.onSortStart,
+                        _useWindowAsScrollContainer =
+                          _this$props3.useWindowAsScrollContainer;
+                      var _node = active.node,
+                        _collection = active.collection;
+                      var _isKeySorting = _this.manager.isKeySorting;
+
+                      var _temp5 = (function() {
+                        if (typeof updateBeforeSortStart === 'function') {
+                          _this._awaitingUpdateBeforeSortStart = true;
+                          return _finallyRethrows(
+                            function() {
+                              var index = _node.sortableInfo.index;
+                              return Promise.resolve(
+                                updateBeforeSortStart(
+                                  {
+                                    collection: _collection,
+                                    index: index,
+                                    node: _node,
+                                    isKeySorting: _isKeySorting,
+                                  },
+                                  event,
+                                ),
+                              ).then(function(result) {
+                                if (result === false) {
+                                  _exit2 = true;
+                                }
+                              });
+                            },
+                            function(_wasThrown, _result) {
+                              _this._awaitingUpdateBeforeSortStart = false;
+                              if (_wasThrown) throw _result;
+                              return _result;
+                            },
+                          );
+                        }
+                      })();
+
+                      return _temp5 && _temp5.then
+                        ? _temp5.then(_temp4)
+                        : _temp4(_temp5);
+                    }
+                  })(),
+                );
+              } catch (e) {
+                return Promise.reject(e);
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleSortMove',
+            function(event) {
+              var onSortMove = _this.props.onSortMove;
+
+              if (typeof event.preventDefault === 'function') {
+                event.preventDefault();
+              }
+
+              _this.updateHelperPosition(event);
+
+              _this.animateNodes();
+
+              _this.autoscroll();
+
+              if (onSortMove) {
+                onSortMove(event);
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleSortEnd',
+            function(event) {
+              var _this$props4 = _this.props,
+                hideSortableGhost = _this$props4.hideSortableGhost,
+                onSortEnd = _this$props4.onSortEnd;
+              var _this$manager = _this.manager,
+                collection = _this$manager.active.collection,
+                isKeySorting = _this$manager.isKeySorting;
+              var nodes = _this.manager.refs[collection];
+
+              if (_this.listenerNode) {
+                if (isKeySorting) {
+                  _this.listenerNode.removeEventListener(
+                    'wheel',
+                    _this.handleKeyEnd,
+                    true,
+                  );
+
+                  _this.listenerNode.removeEventListener(
+                    'mousedown',
+                    _this.handleKeyEnd,
+                    true,
+                  );
+
+                  _this.listenerNode.removeEventListener(
+                    'keydown',
+                    _this.handleKeyDown,
+                  );
+                } else {
+                  events.move.forEach(function(eventName) {
+                    return _this.listenerNode.removeEventListener(
+                      eventName,
+                      _this.handleSortMove,
+                    );
+                  });
+                  events.end.forEach(function(eventName) {
+                    return _this.listenerNode.removeEventListener(
+                      eventName,
+                      _this.handleSortEnd,
+                    );
+                  });
+                }
+              }
+
+              _this.helper.parentNode.removeChild(_this.helper);
+
+              if (hideSortableGhost && _this.sortableGhost) {
+                setInlineStyles(_this.sortableGhost, {
+                  opacity: '',
+                  visibility: '',
+                });
+              }
+
+              for (var i = 0, len = nodes.length; i < len; i++) {
+                var _node2 = nodes[i];
+                var el = _node2.node;
+                _node2.edgeOffset = null;
+                _node2.boundingClientRect = null;
+                setTranslate3d(el, null);
+                setTransitionDuration(el, null);
+                _node2.translate = null;
+              }
+
+              _this.autoScroller.clear();
+
+              _this.manager.active = null;
+              _this.manager.isKeySorting = false;
+
+              _this.setState({
+                sorting: false,
+                sortingIndex: null,
+              });
+
+              if (typeof onSortEnd === 'function') {
+                onSortEnd(
+                  {
+                    collection: collection,
+                    newIndex: _this.newIndex,
+                    oldIndex: _this.index,
+                    isKeySorting: isKeySorting,
+                  },
+                  event,
+                );
+              }
+
+              _this.touched = false;
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'autoscroll',
+            function() {
+              var disableAutoscroll = _this.props.disableAutoscroll;
+              var isKeySorting = _this.manager.isKeySorting;
+
+              if (disableAutoscroll) {
+                _this.autoScroller.clear();
+
+                return;
+              }
+
+              if (isKeySorting) {
+                var translate = objectSpread({}, _this.translate);
+
+                var scrollX = 0;
+                var scrollY = 0;
+
+                if (_this.axis.x) {
+                  translate.x = Math.min(
+                    _this.maxTranslate.x,
+                    Math.max(_this.minTranslate.x, _this.translate.x),
+                  );
+                  scrollX = _this.translate.x - translate.x;
+                }
+
+                if (_this.axis.y) {
+                  translate.y = Math.min(
+                    _this.maxTranslate.y,
+                    Math.max(_this.minTranslate.y, _this.translate.y),
+                  );
+                  scrollY = _this.translate.y - translate.y;
+                }
+
+                _this.translate = translate;
+                setTranslate3d(_this.helper, _this.translate);
+                _this.scrollContainer.scrollLeft += scrollX;
+                _this.scrollContainer.scrollTop += scrollY;
+                return;
+              }
+
+              _this.autoScroller.update({
+                height: _this.height,
+                maxTranslate: _this.maxTranslate,
+                minTranslate: _this.minTranslate,
+                translate: _this.translate,
+                width: _this.width,
+              });
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'onAutoScroll',
+            function(offset) {
+              _this.translate.x += offset.left;
+              _this.translate.y += offset.top;
+
+              _this.animateNodes();
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleKeyDown',
+            function(event) {
+              var keyCode = event.keyCode;
+              var _this$props5 = _this.props,
+                shouldCancelStart = _this$props5.shouldCancelStart,
+                _this$props5$keyCodes = _this$props5.keyCodes,
+                customKeyCodes =
+                  _this$props5$keyCodes === void 0 ? {} : _this$props5$keyCodes;
+
+              var keyCodes = objectSpread({}, defaultKeyCodes, customKeyCodes);
+
+              if (
+                (_this.manager.active && !_this.manager.isKeySorting) ||
+                (!_this.manager.active &&
+                  (!keyCodes.lift.includes(keyCode) ||
+                    shouldCancelStart(event) ||
+                    !_this.isValidSortingTarget(event)))
+              ) {
+                return;
+              }
+
+              event.stopPropagation();
+              event.preventDefault();
+
+              if (keyCodes.lift.includes(keyCode) && !_this.manager.active) {
+                _this.keyLift(event);
+              } else if (
+                keyCodes.drop.includes(keyCode) &&
+                _this.manager.active
+              ) {
+                _this.keyDrop(event);
+              } else if (keyCodes.cancel.includes(keyCode)) {
+                _this.newIndex = _this.manager.active.index;
+
+                _this.keyDrop(event);
+              } else if (keyCodes.up.includes(keyCode)) {
+                _this.keyMove(-1);
+              } else if (keyCodes.down.includes(keyCode)) {
+                _this.keyMove(1);
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'keyLift',
+            function(event) {
+              var target = event.target;
+              var node = closest(target, function(el) {
+                return el.sortableInfo != null;
+              });
+              var _node$sortableInfo2 = node.sortableInfo,
+                index = _node$sortableInfo2.index,
+                collection = _node$sortableInfo2.collection;
+              _this.initialFocusedNode = target;
+              _this.manager.isKeySorting = true;
+              _this.manager.active = {
+                index: index,
+                collection: collection,
+              };
+
+              _this.handlePress(event);
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'keyMove',
+            function(shift) {
+              var nodes = _this.manager.getOrderedRefs();
+
+              var lastIndex = nodes[nodes.length - 1].node.sortableInfo.index;
+              var newIndex = _this.newIndex + shift;
+              var prevIndex = _this.newIndex;
+
+              if (newIndex < 0 || newIndex > lastIndex) {
+                return;
+              }
+
+              _this.prevIndex = prevIndex;
+              _this.newIndex = newIndex;
+              var targetIndex = getTargetIndex(
+                _this.newIndex,
+                _this.prevIndex,
+                _this.index,
+              );
+              var target = nodes.find(function(_ref2) {
+                var node = _ref2.node;
+                return node.sortableInfo.index === targetIndex;
+              });
+              var targetNode = target.node;
+              var scrollDelta = _this.containerScrollDelta;
+              var targetBoundingClientRect =
+                target.boundingClientRect ||
+                getScrollAdjustedBoundingClientRect(targetNode, scrollDelta);
+              var targetTranslate = target.translate || {
+                x: 0,
+                y: 0,
+              };
+              var targetPosition = {
+                top:
+                  targetBoundingClientRect.top +
+                  targetTranslate.y -
+                  scrollDelta.top,
+                left:
+                  targetBoundingClientRect.left +
+                  targetTranslate.x -
+                  scrollDelta.left,
+              };
+              var shouldAdjustForSize = prevIndex < newIndex;
+              var sizeAdjustment = {
+                x:
+                  shouldAdjustForSize && _this.axis.x
+                    ? targetNode.offsetWidth - _this.width
+                    : 0,
+                y:
+                  shouldAdjustForSize && _this.axis.y
+                    ? targetNode.offsetHeight - _this.height
+                    : 0,
+              };
+
+              _this.handleSortMove({
+                pageX: targetPosition.left + sizeAdjustment.x,
+                pageY: targetPosition.top + sizeAdjustment.y,
+                ignoreTransition: shift === 0,
+              });
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'keyDrop',
+            function(event) {
+              _this.handleSortEnd(event);
+
+              if (_this.initialFocusedNode) {
+                _this.initialFocusedNode.focus();
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'handleKeyEnd',
+            function(event) {
+              if (_this.manager.active) {
+                _this.keyDrop(event);
+              }
+            },
+          );
+
+          defineProperty(
+            assertThisInitialized(assertThisInitialized(_this)),
+            'isValidSortingTarget',
+            function(event) {
+              var useDragHandle = _this.props.useDragHandle;
+              var target = event.target;
+              var node = closest(target, function(el) {
+                return el.sortableInfo != null;
+              });
+              return (
+                node &&
+                node.sortableInfo &&
+                !node.sortableInfo.disabled &&
+                (useDragHandle ? isSortableHandle(target) : target.sortableInfo)
+              );
+            },
+          );
+
+          validateProps(props);
+          _this.manager = new Manager();
+          _this.events = {
+            end: _this.handleEnd,
+            move: _this.handleMove,
+            start: _this.handleStart,
+          };
+          return _this;
+        }
+
+        createClass(WithSortableContainer, [
+          {
+            key: 'getChildContext',
+            value: function getChildContext() {
+              return {
+                manager: this.manager,
+              };
+            },
+          },
+          {
+            key: 'componentDidMount',
+            value: function componentDidMount() {
+              var _this2 = this;
+
+              var useWindowAsScrollContainer = this.props
+                .useWindowAsScrollContainer;
+              var container = this.getContainer();
+              Promise.resolve(container).then(function(containerNode) {
+                _this2.container = containerNode;
+                _this2.document = _this2.container.ownerDocument || document;
+                var contentWindow =
+                  _this2.props.contentWindow ||
+                  _this2.document.defaultView ||
+                  window;
+                _this2.contentWindow =
+                  typeof contentWindow === 'function'
+                    ? contentWindow()
+                    : contentWindow;
+                _this2.scrollContainer = useWindowAsScrollContainer
+                  ? _this2.document.scrollingElement ||
+                    _this2.document.documentElement
+                  : getScrollingParent(_this2.container) || _this2.container;
+                _this2.autoScroller = new AutoScroller(
+                  _this2.scrollContainer,
+                  _this2.onAutoScroll,
+                );
+                Object.keys(_this2.events).forEach(function(key) {
+                  return events[key].forEach(function(eventName) {
+                    return _this2.container.addEventListener(
+                      eventName,
+                      _this2.events[key],
+                      false,
+                    );
+                  });
+                });
+
+                _this2.container.addEventListener(
+                  'keydown',
+                  _this2.handleKeyDown,
+                );
+              });
+            },
+          },
+          {
+            key: 'componentWillUnmount',
+            value: function componentWillUnmount() {
+              var _this3 = this;
+
+              if (this.helper && this.helper.parentNode) {
+                this.helper.parentNode.removeChild(this.helper);
+              }
+
+              if (!this.container) {
+                return;
+              }
+
+              Object.keys(this.events).forEach(function(key) {
+                return events[key].forEach(function(eventName) {
+                  return _this3.container.removeEventListener(
+                    eventName,
+                    _this3.events[key],
+                  );
+                });
+              });
+              this.container.removeEventListener('keydown', this.handleKeyDown);
+            },
+          },
+          {
+            key: 'updateHelperPosition',
+            value: function updateHelperPosition(event) {
+              var _this$props6 = this.props,
+                lockAxis = _this$props6.lockAxis,
+                lockOffset = _this$props6.lockOffset,
+                lockToContainerEdges = _this$props6.lockToContainerEdges,
+                transitionDuration = _this$props6.transitionDuration,
+                _this$props6$keyboard =
+                  _this$props6.keyboardSortingTransitionDuration,
+                keyboardSortingTransitionDuration =
+                  _this$props6$keyboard === void 0
+                    ? transitionDuration
+                    : _this$props6$keyboard;
+              var isKeySorting = this.manager.isKeySorting;
+              var ignoreTransition = event.ignoreTransition;
+              var offset = getPosition(event);
+              var translate = {
+                x: offset.x - this.initialOffset.x,
+                y: offset.y - this.initialOffset.y,
+              };
+              translate.y -= window.pageYOffset - this.initialWindowScroll.top;
+              translate.x -= window.pageXOffset - this.initialWindowScroll.left;
+              this.translate = translate;
+
+              if (lockToContainerEdges) {
+                var _getLockPixelOffsets = getLockPixelOffsets({
+                    height: this.height,
+                    lockOffset: lockOffset,
+                    width: this.width,
+                  }),
+                  _getLockPixelOffsets2 = slicedToArray(
+                    _getLockPixelOffsets,
+                    2,
+                  ),
+                  minLockOffset = _getLockPixelOffsets2[0],
+                  maxLockOffset = _getLockPixelOffsets2[1];
+
+                var minOffset = {
+                  x: this.width / 2 - minLockOffset.x,
+                  y: this.height / 2 - minLockOffset.y,
+                };
+                var maxOffset = {
+                  x: this.width / 2 - maxLockOffset.x,
+                  y: this.height / 2 - maxLockOffset.y,
+                };
+                translate.x = limit(
+                  this.minTranslate.x + minOffset.x,
+                  this.maxTranslate.x - maxOffset.x,
+                  translate.x,
+                );
+                translate.y = limit(
+                  this.minTranslate.y + minOffset.y,
+                  this.maxTranslate.y - maxOffset.y,
+                  translate.y,
+                );
+              }
+
+              if (lockAxis === 'x') {
+                translate.y = 0;
+              } else if (lockAxis === 'y') {
+                translate.x = 0;
+              }
+
+              if (
+                isKeySorting &&
+                keyboardSortingTransitionDuration &&
+                !ignoreTransition
+              ) {
+                setTransitionDuration(
+                  this.helper,
+                  keyboardSortingTransitionDuration,
+                );
+              }
+
+              setTranslate3d(this.helper, translate);
+            },
+          },
+          {
+            key: 'animateNodes',
+            value: function animateNodes() {
+              var _this$props7 = this.props,
+                transitionDuration = _this$props7.transitionDuration,
+                hideSortableGhost = _this$props7.hideSortableGhost,
+                onSortOver = _this$props7.onSortOver;
+              var containerScrollDelta = this.containerScrollDelta,
+                windowScrollDelta = this.windowScrollDelta;
+              var nodes = this.manager.getOrderedRefs();
+              var sortingOffset = {
+                left:
+                  this.offsetEdge.left +
+                  this.translate.x +
+                  containerScrollDelta.left,
+                top:
+                  this.offsetEdge.top +
+                  this.translate.y +
+                  containerScrollDelta.top,
+              };
+              var isKeySorting = this.manager.isKeySorting;
+              var prevIndex = this.newIndex;
+              this.newIndex = null;
+
+              for (var i = 0, len = nodes.length; i < len; i++) {
+                var _node3 = nodes[i].node;
+                var index = _node3.sortableInfo.index;
+                var width = _node3.offsetWidth;
+                var height = _node3.offsetHeight;
+                var offset = {
+                  height: this.height > height ? height / 2 : this.height / 2,
+                  width: this.width > width ? width / 2 : this.width / 2,
+                };
+                var mustShiftBackward =
+                  isKeySorting && index > this.index && index <= prevIndex;
+                var mustShiftForward =
+                  isKeySorting && index < this.index && index >= prevIndex;
+                var translate = {
+                  x: 0,
+                  y: 0,
+                };
+                var edgeOffset = nodes[i].edgeOffset;
+
+                if (!edgeOffset) {
+                  edgeOffset = getEdgeOffset(_node3, this.container);
+                  nodes[i].edgeOffset = edgeOffset;
+
+                  if (isKeySorting) {
+                    nodes[
+                      i
+                    ].boundingClientRect = getScrollAdjustedBoundingClientRect(
+                      _node3,
+                      containerScrollDelta,
+                    );
+                  }
+                }
+
+                var nextNode = i < nodes.length - 1 && nodes[i + 1];
+                var prevNode = i > 0 && nodes[i - 1];
+
+                if (nextNode && !nextNode.edgeOffset) {
+                  nextNode.edgeOffset = getEdgeOffset(
+                    nextNode.node,
+                    this.container,
+                  );
+
+                  if (isKeySorting) {
+                    nextNode.boundingClientRect = getScrollAdjustedBoundingClientRect(
+                      nextNode.node,
+                      containerScrollDelta,
+                    );
+                  }
+                }
+
+                if (index === this.index) {
+                  if (hideSortableGhost) {
+                    this.sortableGhost = _node3;
+                    setInlineStyles(_node3, {
+                      opacity: 0,
+                      visibility: 'hidden',
+                    });
+                  }
+
+                  continue;
+                }
+
+                if (transitionDuration) {
+                  setTransitionDuration(_node3, transitionDuration);
+                }
+
+                if (this.axis.x) {
+                  if (this.axis.y) {
+                    if (
+                      mustShiftForward ||
+                      (index < this.index &&
+                        ((sortingOffset.left +
+                          windowScrollDelta.left -
+                          offset.width <=
+                          edgeOffset.left &&
+                          sortingOffset.top + windowScrollDelta.top <=
+                            edgeOffset.top + offset.height) ||
+                          sortingOffset.top +
+                            windowScrollDelta.top +
+                            offset.height <=
+                            edgeOffset.top))
+                    ) {
+                      translate.x = this.width + this.marginOffset.x;
+
+                      if (
+                        edgeOffset.left + translate.x >
+                        this.containerBoundingRect.width - offset.width
+                      ) {
+                        if (nextNode) {
+                          translate.x =
+                            nextNode.edgeOffset.left - edgeOffset.left;
+                          translate.y =
+                            nextNode.edgeOffset.top - edgeOffset.top;
+                        }
+                      }
+
+                      if (this.newIndex === null) {
+                        this.newIndex = index;
+                      }
+                    } else if (
+                      mustShiftBackward ||
+                      (index > this.index &&
+                        ((sortingOffset.left +
+                          windowScrollDelta.left +
+                          offset.width >=
+                          edgeOffset.left &&
+                          sortingOffset.top +
+                            windowScrollDelta.top +
+                            offset.height >=
+                            edgeOffset.top) ||
+                          sortingOffset.top +
+                            windowScrollDelta.top +
+                            offset.height >=
+                            edgeOffset.top + height))
+                    ) {
+                      translate.x = -(this.width + this.marginOffset.x);
+
+                      if (
+                        edgeOffset.left + translate.x <
+                        this.containerBoundingRect.left + offset.width
+                      ) {
+                        if (prevNode) {
+                          translate.x =
+                            prevNode.edgeOffset.left - edgeOffset.left;
+                          translate.y =
+                            prevNode.edgeOffset.top - edgeOffset.top;
+                        }
+                      }
+
+                      this.newIndex = index;
+                    }
+                  } else {
+                    if (
+                      mustShiftBackward ||
+                      (index > this.index &&
+                        sortingOffset.left +
+                          windowScrollDelta.left +
+                          offset.width >=
+                          edgeOffset.left)
+                    ) {
+                      translate.x = -(this.width + this.marginOffset.x);
+                      this.newIndex = index;
+                    } else if (
+                      mustShiftForward ||
+                      (index < this.index &&
+                        sortingOffset.left + windowScrollDelta.left <=
+                          edgeOffset.left + offset.width)
+                    ) {
+                      translate.x = this.width + this.marginOffset.x;
+
+                      if (this.newIndex == null) {
+                        this.newIndex = index;
+                      }
+                    }
+                  }
+                } else if (this.axis.y) {
+                  if (
+                    mustShiftBackward ||
+                    (index > this.index &&
+                      sortingOffset.top +
+                        windowScrollDelta.top +
+                        offset.height >=
+                        edgeOffset.top)
+                  ) {
+                    translate.y = -(this.height + this.marginOffset.y);
+                    this.newIndex = index;
+                  } else if (
+                    mustShiftForward ||
+                    (index < this.index &&
+                      sortingOffset.top + windowScrollDelta.top <=
+                        edgeOffset.top + offset.height)
+                  ) {
+                    translate.y = this.height + this.marginOffset.y;
+
+                    if (this.newIndex == null) {
+                      this.newIndex = index;
+                    }
+                  }
+                }
+
+                setTranslate3d(_node3, translate);
+                nodes[i].translate = translate;
+              }
+
+              if (this.newIndex == null) {
+                this.newIndex = this.index;
+              }
+
+              if (isKeySorting) {
+                this.newIndex = prevIndex;
+              }
+
+              var oldIndex = isKeySorting ? this.prevIndex : prevIndex;
+
+              if (onSortOver && this.newIndex !== oldIndex) {
+                onSortOver({
+                  collection: this.manager.active.collection,
+                  index: this.index,
+                  newIndex: this.newIndex,
+                  oldIndex: oldIndex,
+                  isKeySorting: isKeySorting,
+                });
+              }
+            },
+          },
+          {
+            key: 'getWrappedInstance',
+            value: function getWrappedInstance() {
+              invariant_1(
+                config.withRef,
+                'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call',
+              );
+              return this.refs.wrappedInstance;
+            },
+          },
+          {
+            key: 'getContainer',
+            value: function getContainer() {
+              var getContainer = this.props.getContainer;
+
+              if (typeof getContainer !== 'function') {
+                return reactDom.findDOMNode(this);
+              }
+
+              return getContainer(
+                config.withRef ? this.getWrappedInstance() : undefined,
+              );
+            },
+          },
+          {
+            key: 'render',
+            value: function render() {
+              var ref = config.withRef ? 'wrappedInstance' : null;
+              return React.createElement(
+                WrappedComponent,
+                _extends_1(
+                  {
+                    ref: ref,
+                  },
+                  omit(this.props, omittedProps),
+                ),
+              );
+            },
+          },
+          {
+            key: 'helperContainer',
+            get: function get() {
+              var helperContainer = this.props.helperContainer;
+
+              if (typeof helperContainer === 'function') {
+                return helperContainer();
+              }
+
+              return this.props.helperContainer || this.document.body;
+            },
+          },
+          {
+            key: 'containerScrollDelta',
+            get: function get() {
+              var useWindowAsScrollContainer = this.props
+                .useWindowAsScrollContainer;
+
+              if (useWindowAsScrollContainer) {
+                return {
+                  left: 0,
+                  top: 0,
+                };
+              }
+
+              return {
+                left: this.scrollContainer.scrollLeft - this.initialScroll.left,
+                top: this.scrollContainer.scrollTop - this.initialScroll.top,
+              };
+            },
+          },
+          {
+            key: 'windowScrollDelta',
+            get: function get() {
+              return {
+                left:
+                  this.contentWindow.pageXOffset -
+                  this.initialWindowScroll.left,
+                top:
+                  this.contentWindow.pageYOffset - this.initialWindowScroll.top,
+              };
+            },
+          },
+        ]);
+
+        return WithSortableContainer;
+      })(React.Component)),
+      defineProperty(
+        _class,
+        'displayName',
+        provideDisplayName('sortableList', WrappedComponent),
+      ),
+      defineProperty(_class, 'defaultProps', defaultProps),
+      defineProperty(_class, 'propTypes', propTypes),
+      defineProperty(_class, 'childContextTypes', {
+        manager: PropTypes.object.isRequired,
+      }),
+      _temp
+    );
+  }
+
+  var propTypes$1 = {
+    index: PropTypes.number.isRequired,
+    collection: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    disabled: PropTypes.bool,
+  };
+  var omittedProps$1 = Object.keys(propTypes$1);
+  function sortableElement(WrappedComponent) {
+    var _class, _temp;
+
+    var config =
+      arguments.length > 1 && arguments[1] !== undefined
+        ? arguments[1]
+        : {
+            withRef: false,
+          };
+    return (
+      (_temp = _class = (function(_React$Component) {
+        inherits(WithSortableElement, _React$Component);
+
+        function WithSortableElement() {
+          classCallCheck(this, WithSortableElement);
+
+          return possibleConstructorReturn(
+            this,
+            getPrototypeOf(WithSortableElement).apply(this, arguments),
+          );
+        }
+
+        createClass(WithSortableElement, [
+          {
+            key: 'componentDidMount',
+            value: function componentDidMount() {
+              this.register();
+            },
+          },
+          {
+            key: 'componentDidUpdate',
+            value: function componentDidUpdate(prevProps) {
+              if (this.node) {
+                if (prevProps.index !== this.props.index) {
+                  this.node.sortableInfo.index = this.props.index;
+                }
+
+                if (prevProps.disabled !== this.props.disabled) {
+                  this.node.sortableInfo.disabled = this.props.disabled;
+                }
+              }
+
+              if (prevProps.collection !== this.props.collection) {
+                this.unregister(prevProps.collection);
+                this.register();
+              }
+            },
+          },
+          {
+            key: 'componentWillUnmount',
+            value: function componentWillUnmount() {
+              this.unregister();
+            },
+          },
+          {
+            key: 'register',
+            value: function register() {
+              var _this$props = this.props,
+                collection = _this$props.collection,
+                disabled = _this$props.disabled,
+                index = _this$props.index;
+              var node = reactDom.findDOMNode(this);
+              node.sortableInfo = {
+                collection: collection,
+                disabled: disabled,
+                index: index,
+                manager: this.context.manager,
+              };
+              this.node = node;
+              this.ref = {
+                node: node,
+              };
+              this.context.manager.add(collection, this.ref);
+            },
+          },
+          {
+            key: 'unregister',
+            value: function unregister() {
+              var collection =
+                arguments.length > 0 && arguments[0] !== undefined
+                  ? arguments[0]
+                  : this.props.collection;
+              this.context.manager.remove(collection, this.ref);
+            },
+          },
+          {
+            key: 'getWrappedInstance',
+            value: function getWrappedInstance() {
+              invariant_1(
+                config.withRef,
+                'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableElement() call',
+              );
+              return this.refs.wrappedInstance;
+            },
+          },
+          {
+            key: 'render',
+            value: function render() {
+              var ref = config.withRef ? 'wrappedInstance' : null;
+              return React.createElement(
+                WrappedComponent,
+                _extends_1(
+                  {
+                    ref: ref,
+                  },
+                  omit(this.props, omittedProps$1),
+                ),
+              );
+            },
+          },
+        ]);
+
+        return WithSortableElement;
+      })(React.Component)),
+      defineProperty(
+        _class,
+        'displayName',
+        provideDisplayName('sortableElement', WrappedComponent),
+      ),
+      defineProperty(_class, 'contextTypes', {
+        manager: PropTypes.object.isRequired,
+      }),
+      defineProperty(_class, 'propTypes', propTypes$1),
+      defineProperty(_class, 'defaultProps', {
+        collection: 0,
+      }),
+      _temp
+    );
+  }
+
+  exports.SortableContainer = sortableContainer;
+  exports.sortableContainer = sortableContainer;
+  exports.SortableElement = sortableElement;
+  exports.sortableElement = sortableElement;
+  exports.SortableHandle = sortableHandle;
+  exports.sortableHandle = sortableHandle;
+  exports.arrayMove = arrayMove;
+
+  Object.defineProperty(exports, '__esModule', {value: true});
+});

--- a/dist/react-sortable-hoc.umd.min.js
+++ b/dist/react-sortable-hoc.umd.min.js
@@ -1,0 +1,1564 @@
+!(function(e, t) {
+  'object' == typeof exports && 'undefined' != typeof module
+    ? t(exports, require('react'), require('prop-types'), require('react-dom'))
+    : 'function' == typeof define && define.amd
+    ? define(['exports', 'react', 'prop-types', 'react-dom'], t)
+    : t(((e = e || self).SortableHOC = {}), e.React, e.PropTypes, e.ReactDOM);
+})(this, function(e, r, i, a) {
+  'use strict';
+  function t(e, t) {
+    return e((t = {exports: {}}), t.exports), t.exports;
+  }
+  i = i && i.hasOwnProperty('default') ? i.default : i;
+  var s = t(function(e) {
+    function t() {
+      return (
+        (e.exports = t =
+          Object.assign ||
+          function(e) {
+            for (var t = 1; t < arguments.length; t++) {
+              var n = arguments[t];
+              for (var o in n)
+                Object.prototype.hasOwnProperty.call(n, o) && (e[o] = n[o]);
+            }
+            return e;
+          }),
+        t.apply(this, arguments)
+      );
+    }
+    e.exports = t;
+  });
+  var n = function(e) {
+    if (Array.isArray(e)) return e;
+  };
+  var o = function(e, t) {
+    var n = [],
+      o = !0,
+      r = !1,
+      i = void 0;
+    try {
+      for (
+        var a, s = e[Symbol.iterator]();
+        !(o = (a = s.next()).done) && (n.push(a.value), !t || n.length !== t);
+        o = !0
+      );
+    } catch (e) {
+      (r = !0), (i = e);
+    } finally {
+      try {
+        o || null == s.return || s.return();
+      } finally {
+        if (r) throw i;
+      }
+    }
+    return n;
+  };
+  var l = function() {
+    throw new TypeError('Invalid attempt to destructure non-iterable instance');
+  };
+  var b = function(e, t) {
+    return n(e) || o(e, t) || l();
+  };
+  var c = function(e, t, n) {
+    return (
+      t in e
+        ? Object.defineProperty(e, t, {
+            value: n,
+            enumerable: !0,
+            configurable: !0,
+            writable: !0,
+          })
+        : (e[t] = n),
+      e
+    );
+  };
+  var R = function(t) {
+    for (var e = 1; e < arguments.length; e++) {
+      var n = null != arguments[e] ? arguments[e] : {},
+        o = Object.keys(n);
+      'function' == typeof Object.getOwnPropertySymbols &&
+        (o = o.concat(
+          Object.getOwnPropertySymbols(n).filter(function(e) {
+            return Object.getOwnPropertyDescriptor(n, e).enumerable;
+          }),
+        )),
+        o.forEach(function(e) {
+          c(t, e, n[e]);
+        });
+    }
+    return t;
+  };
+  var u = function(e, t) {
+    if (!(e instanceof t))
+      throw new TypeError('Cannot call a class as a function');
+  };
+  function d(e, t) {
+    for (var n = 0; n < t.length; n++) {
+      var o = t[n];
+      (o.enumerable = o.enumerable || !1),
+        (o.configurable = !0),
+        'value' in o && (o.writable = !0),
+        Object.defineProperty(e, o.key, o);
+    }
+  }
+  var f = function(e, t, n) {
+      return t && d(e.prototype, t), n && d(e, n), e;
+    },
+    h = t(function(t) {
+      function n(e) {
+        return (n =
+          'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+            ? function(e) {
+                return typeof e;
+              }
+            : function(e) {
+                return e &&
+                  'function' == typeof Symbol &&
+                  e.constructor === Symbol &&
+                  e !== Symbol.prototype
+                  ? 'symbol'
+                  : typeof e;
+              })(e);
+      }
+      function o(e) {
+        return (
+          'function' == typeof Symbol && 'symbol' === n(Symbol.iterator)
+            ? (t.exports = o = function(e) {
+                return n(e);
+              })
+            : (t.exports = o = function(e) {
+                return e &&
+                  'function' == typeof Symbol &&
+                  e.constructor === Symbol &&
+                  e !== Symbol.prototype
+                  ? 'symbol'
+                  : n(e);
+              }),
+          o(e)
+        );
+      }
+      t.exports = o;
+    });
+  var p = function(e) {
+    if (void 0 === e)
+      throw new ReferenceError(
+        "this hasn't been initialised - super() hasn't been called",
+      );
+    return e;
+  };
+  var y = function(e, t) {
+      return !t || ('object' !== h(t) && 'function' != typeof t) ? p(e) : t;
+    },
+    g = t(function(t) {
+      function n(e) {
+        return (
+          (t.exports = n = Object.setPrototypeOf
+            ? Object.getPrototypeOf
+            : function(e) {
+                return e.__proto__ || Object.getPrototypeOf(e);
+              }),
+          n(e)
+        );
+      }
+      t.exports = n;
+    }),
+    v = t(function(n) {
+      function o(e, t) {
+        return (
+          (n.exports = o =
+            Object.setPrototypeOf ||
+            function(e, t) {
+              return (e.__proto__ = t), e;
+            }),
+          o(e, t)
+        );
+      }
+      n.exports = o;
+    });
+  var m = function(e, t) {
+      if ('function' != typeof t && null !== t)
+        throw new TypeError(
+          'Super expression must either be null or a function',
+        );
+      (e.prototype = Object.create(t && t.prototype, {
+        constructor: {value: e, writable: !0, configurable: !0},
+      })),
+        t && v(e, t);
+    },
+    w = function(e, t, n, o, r, i, a, s) {
+      if (!e) {
+        var l;
+        if (void 0 === t)
+          l = new Error(
+            'Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings.',
+          );
+        else {
+          var c = [n, o, r, i, a, s],
+            u = 0;
+          (l = new Error(
+            t.replace(/%s/g, function() {
+              return c[u++];
+            }),
+          )).name = 'Invariant Violation';
+        }
+        throw ((l.framesToPop = 1), l);
+      }
+    },
+    x = (function() {
+      function e() {
+        u(this, e), c(this, 'refs', {});
+      }
+      return (
+        f(e, [
+          {
+            key: 'add',
+            value: function(e, t) {
+              this.refs[e] || (this.refs[e] = []), this.refs[e].push(t);
+            },
+          },
+          {
+            key: 'remove',
+            value: function(e, t) {
+              var n = this.getIndex(e, t);
+              -1 !== n && this.refs[e].splice(n, 1);
+            },
+          },
+          {
+            key: 'isActive',
+            value: function() {
+              return this.active;
+            },
+          },
+          {
+            key: 'getActive',
+            value: function() {
+              var t = this;
+              return this.refs[this.active.collection].find(function(e) {
+                return e.node.sortableInfo.index == t.active.index;
+              });
+            },
+          },
+          {
+            key: 'getIndex',
+            value: function(e, t) {
+              return this.refs[e].indexOf(t);
+            },
+          },
+          {
+            key: 'getOrderedRefs',
+            value: function() {
+              var e =
+                0 < arguments.length && void 0 !== arguments[0]
+                  ? arguments[0]
+                  : this.active.collection;
+              return this.refs[e].sort(S);
+            },
+          },
+        ]),
+        e
+      );
+    })();
+  function S(e, t) {
+    return e.node.sortableInfo.index - t.node.sortableInfo.index;
+  }
+  var O = function(e) {
+    if (Array.isArray(e)) {
+      for (var t = 0, n = new Array(e.length); t < e.length; t++) n[t] = e[t];
+      return n;
+    }
+  };
+  var T = function(e) {
+    if (
+      Symbol.iterator in Object(e) ||
+      '[object Arguments]' === Object.prototype.toString.call(e)
+    )
+      return Array.from(e);
+  };
+  var C = function() {
+    throw new TypeError('Invalid attempt to spread non-iterable instance');
+  };
+  var D = function(e) {
+    return O(e) || T(e) || C();
+  };
+  function k(n, o) {
+    return Object.keys(n).reduce(function(e, t) {
+      return -1 === o.indexOf(t) && (e[t] = n[t]), e;
+    }, {});
+  }
+  var N = {
+      end: ['touchend', 'touchcancel', 'mouseup'],
+      move: ['touchmove', 'mousemove'],
+      start: ['touchstart', 'mousedown'],
+    },
+    I = (function() {
+      if ('undefined' == typeof window || 'undefined' == typeof document)
+        return '';
+      var e = window.getComputedStyle(document.documentElement, '') || [
+          '-moz-hidden-iframe',
+        ],
+        t = (Array.prototype.slice
+          .call(e)
+          .join('')
+          .match(/-(moz|webkit|ms)-/) ||
+          ('' === e.OLink && ['', 'o']))[1];
+      switch (t) {
+        case 'ms':
+          return 'ms';
+        default:
+          return t && t.length ? t[0].toUpperCase() + t.substr(1) : '';
+      }
+    })();
+  function A(t, n) {
+    Object.keys(n).forEach(function(e) {
+      t.style[e] = n[e];
+    });
+  }
+  function M(e, t) {
+    e.style[''.concat(I, 'Transform')] =
+      null == t ? '' : 'translate3d('.concat(t.x, 'px,').concat(t.y, 'px,0)');
+  }
+  function W(e, t) {
+    e.style[''.concat(I, 'TransitionDuration')] =
+      null == t ? '' : ''.concat(t, 'ms');
+  }
+  function L(e, t) {
+    for (; e; ) {
+      if (t(e)) return e;
+      e = e.parentNode;
+    }
+    return null;
+  }
+  function E(e, t, n) {
+    return Math.max(e, Math.min(n, t));
+  }
+  function P(e) {
+    return 'px' === e.substr(-2) ? parseFloat(e) : 0;
+  }
+  function j(e, t) {
+    var n = t.displayName || t.name;
+    return n ? ''.concat(e, '(').concat(n, ')') : e;
+  }
+  function H(e, t) {
+    var n = e.getBoundingClientRect();
+    return {top: n.top + t.top, left: n.left + t.left};
+  }
+  function K(e) {
+    return e.touches && e.touches.length
+      ? {x: e.touches[0].pageX, y: e.touches[0].pageY}
+      : e.changedTouches && e.changedTouches.length
+      ? {x: e.changedTouches[0].pageX, y: e.changedTouches[0].pageY}
+      : {x: e.pageX, y: e.pageY};
+  }
+  function _(e, t) {
+    var n =
+      2 < arguments.length && void 0 !== arguments[2]
+        ? arguments[2]
+        : {left: 0, top: 0};
+    if (e) {
+      var o = {left: n.left + e.offsetLeft, top: n.top + e.offsetTop};
+      return e.parentNode === t ? o : _(e.parentNode, t, o);
+    }
+  }
+  function B(e) {
+    var t = e.lockOffset,
+      n = e.width,
+      o = e.height,
+      r = t,
+      i = t,
+      a = 'px';
+    if ('string' == typeof t) {
+      var s = /^[+-]?\d*(?:\.\d*)?(px|%)$/.exec(t);
+      w(
+        null !== s,
+        'lockOffset value should be a number or a string of a number followed by "px" or "%". Given %s',
+        t,
+      ),
+        (r = parseFloat(t)),
+        (i = parseFloat(t)),
+        (a = s[1]);
+    }
+    return (
+      w(
+        isFinite(r) && isFinite(i),
+        'lockOffset value should be a finite. Given %s',
+        t,
+      ),
+      '%' === a && ((r = (r * n) / 100), (i = (i * o) / 100)),
+      {x: r, y: i}
+    );
+  }
+  function G(e) {
+    return e instanceof HTMLElement
+      ? ((t = e),
+        (n = window.getComputedStyle(t)),
+        (o = /(auto|scroll)/),
+        ['overflow', 'overflowX', 'overflowY'].find(function(e) {
+          return o.test(n[e]);
+        })
+          ? e
+          : G(e.parentNode))
+      : null;
+    var t, n, o;
+  }
+  var X = 27,
+    U = 32,
+    Y = 37,
+    q = 38,
+    F = 39,
+    V = 40,
+    z = {
+      Anchor: 'A',
+      Button: 'BUTTON',
+      Canvas: 'CANVAS',
+      Input: 'INPUT',
+      Option: 'OPTION',
+      Textarea: 'TEXTAREA',
+      Select: 'SELECT',
+    };
+  function $(n) {
+    var e,
+      t,
+      o =
+        1 < arguments.length && void 0 !== arguments[1]
+          ? arguments[1]
+          : {withRef: !1};
+    return (
+      (t = e = (function(e) {
+        function t() {
+          return u(this, t), y(this, g(t).apply(this, arguments));
+        }
+        return (
+          m(t, e),
+          f(t, [
+            {
+              key: 'componentDidMount',
+              value: function() {
+                a.findDOMNode(this).sortableHandle = !0;
+              },
+            },
+            {
+              key: 'getWrappedInstance',
+              value: function() {
+                return (
+                  w(
+                    o.withRef,
+                    'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableHandle() call',
+                  ),
+                  this.refs.wrappedInstance
+                );
+              },
+            },
+            {
+              key: 'render',
+              value: function() {
+                var e = o.withRef ? 'wrappedInstance' : null;
+                return r.createElement(n, s({ref: e}, this.props));
+              },
+            },
+          ]),
+          t
+        );
+      })(r.Component)),
+      c(e, 'displayName', j('sortableHandle', n)),
+      t
+    );
+  }
+  function J(e) {
+    return null != e.sortableHandle;
+  }
+  var Q = (function() {
+    function n(e, t) {
+      u(this, n), (this.container = e), (this.onScrollCallback = t);
+    }
+    return (
+      f(n, [
+        {
+          key: 'clear',
+          value: function() {
+            null != this.interval &&
+              (clearInterval(this.interval), (this.interval = null));
+          },
+        },
+        {
+          key: 'update',
+          value: function(e) {
+            var t = this,
+              n = e.translate,
+              o = e.minTranslate,
+              r = e.maxTranslate,
+              i = e.width,
+              a = e.height,
+              s = {x: 0, y: 0},
+              l = {x: 1, y: 1},
+              c = 10,
+              u = 10,
+              d = this.container,
+              f = d.scrollTop,
+              h = d.scrollLeft,
+              p = d.scrollHeight,
+              y = d.scrollWidth,
+              g = 0 === f,
+              v = p - f - d.clientHeight == 0,
+              m = 0 === h,
+              x = y - h - d.clientWidth == 0;
+            n.y >= r.y - a / 2 && !v
+              ? ((s.y = 1), (l.y = u * Math.abs((r.y - a / 2 - n.y) / a)))
+              : n.x >= r.x - i / 2 && !x
+              ? ((s.x = 1), (l.x = c * Math.abs((r.x - i / 2 - n.x) / i)))
+              : n.y <= o.y + a / 2 && !g
+              ? ((s.y = -1), (l.y = u * Math.abs((n.y - a / 2 - o.y) / a)))
+              : n.x <= o.x + i / 2 &&
+                !m &&
+                ((s.x = -1), (l.x = c * Math.abs((n.x - i / 2 - o.x) / i))),
+              this.interval && (this.clear(), (this.isAutoScrolling = !1)),
+              (0 === s.x && 0 === s.y) ||
+                (this.interval = setInterval(function() {
+                  t.isAutoScrolling = !0;
+                  var e = {left: l.x * s.x, top: l.y * s.y};
+                  (t.container.scrollTop += e.top),
+                    (t.container.scrollLeft += e.left),
+                    t.onScrollCallback(e);
+                }, 5));
+          },
+        },
+      ]),
+      n
+    );
+  })();
+  var Z = {
+      axis: i.oneOf(['x', 'y', 'xy']),
+      contentWindow: i.any,
+      disableAutoscroll: i.bool,
+      distance: i.number,
+      getContainer: i.func,
+      getHelperDimensions: i.func,
+      helperClass: i.string,
+      helperContainer: i.oneOfType([
+        i.func,
+        'undefined' == typeof HTMLElement ? i.any : i.instanceOf(HTMLElement),
+      ]),
+      hideSortableGhost: i.bool,
+      keyboardSortingTransitionDuration: i.number,
+      lockAxis: i.string,
+      lockOffset: i.oneOfType([
+        i.number,
+        i.string,
+        i.arrayOf(i.oneOfType([i.number, i.string])),
+      ]),
+      lockToContainerEdges: i.bool,
+      onSortEnd: i.func,
+      onSortMove: i.func,
+      onSortOver: i.func,
+      onSortStart: i.func,
+      pressDelay: i.number,
+      pressThreshold: i.number,
+      keyCodes: i.shape({
+        lift: i.arrayOf(i.number),
+        drop: i.arrayOf(i.number),
+        cancel: i.arrayOf(i.number),
+        up: i.arrayOf(i.number),
+        down: i.arrayOf(i.number),
+      }),
+      shouldCancelStart: i.func,
+      transitionDuration: i.number,
+      updateBeforeSortStart: i.func,
+      useDragHandle: i.bool,
+      useWindowAsScrollContainer: i.bool,
+    },
+    ee = {lift: [U], drop: [U], cancel: [X], up: [q, Y], down: [V, F]},
+    te = {
+      axis: 'y',
+      disableAutoscroll: !1,
+      distance: 0,
+      getHelperDimensions: function(e) {
+        var t = e.node;
+        return {height: t.offsetHeight, width: t.offsetWidth};
+      },
+      hideSortableGhost: !0,
+      lockOffset: '50%',
+      lockToContainerEdges: !1,
+      pressDelay: 0,
+      pressThreshold: 5,
+      keyCodes: ee,
+      shouldCancelStart: function(e) {
+        return (
+          -1 !==
+            [z.Input, z.Textarea, z.Select, z.Option, z.Button].indexOf(
+              e.target.tagName,
+            ) ||
+          !!L(e.target, function(e) {
+            return 'true' === e.contentEditable;
+          })
+        );
+      },
+      transitionDuration: 300,
+      useWindowAsScrollContainer: !1,
+    },
+    ne = Object.keys(Z);
+  function oe(t) {
+    var e,
+      n,
+      o =
+        1 < arguments.length && void 0 !== arguments[1]
+          ? arguments[1]
+          : {withRef: !1};
+    return (
+      (n = e = (function(e) {
+        function n(e) {
+          var E, t;
+          return (
+            u(this, n),
+            (E = y(this, g(n).call(this, e))),
+            c(p(p(E)), 'state', {}),
+            c(p(p(E)), 'handleStart', function(e) {
+              var t = E.props,
+                n = t.distance,
+                o = t.shouldCancelStart;
+              if (2 !== e.button && !o(e)) {
+                (E.touched = !0), (E.position = K(e));
+                var r,
+                  i = L(e.target, function(e) {
+                    return null != e.sortableInfo;
+                  });
+                if (
+                  i &&
+                  i.sortableInfo &&
+                  E.nodeIsChild(i) &&
+                  !E.state.sorting
+                ) {
+                  var a = E.props.useDragHandle,
+                    s = i.sortableInfo,
+                    l = s.index,
+                    c = s.collection;
+                  if (s.disabled) return;
+                  if (a && !L(e.target, J)) return;
+                  (E.manager.active = {collection: c, index: l}),
+                    ((r = e).touches && r.touches.length) ||
+                      (r.changedTouches && r.changedTouches.length) ||
+                      e.target.tagName !== z.Anchor ||
+                      e.preventDefault(),
+                    n ||
+                      (0 === E.props.pressDelay
+                        ? E.handlePress(e)
+                        : (E.pressTimer = setTimeout(function() {
+                            return E.handlePress(e);
+                          }, E.props.pressDelay)));
+                }
+              }
+            }),
+            c(p(p(E)), 'nodeIsChild', function(e) {
+              return e.sortableInfo.manager === E.manager;
+            }),
+            c(p(p(E)), 'handleMove', function(e) {
+              var t = E.props,
+                n = t.distance,
+                o = t.pressThreshold;
+              if (
+                !E.state.sorting &&
+                E.touched &&
+                !E._awaitingUpdateBeforeSortStart
+              ) {
+                var r = K(e),
+                  i = {x: E.position.x - r.x, y: E.position.y - r.y},
+                  a = Math.abs(i.x) + Math.abs(i.y);
+                (E.delta = i),
+                  n || (o && !(o <= a))
+                    ? n && n <= a && E.manager.isActive() && E.handlePress(e)
+                    : (clearTimeout(E.cancelTimer),
+                      (E.cancelTimer = setTimeout(E.cancel, 0)));
+              }
+            }),
+            c(p(p(E)), 'handleEnd', function() {
+              (E.touched = !1), E.cancel();
+            }),
+            c(p(p(E)), 'cancel', function() {
+              var e = E.props.distance;
+              E.state.sorting ||
+                (e || clearTimeout(E.pressTimer), (E.manager.active = null));
+            }),
+            c(p(p(E)), 'handlePress', function(k) {
+              try {
+                var I = !1,
+                  r = E.manager.getActive();
+                return Promise.resolve(
+                  (function() {
+                    if (r) {
+                      var e = function(e) {
+                          if (I) return e;
+                          var t,
+                            n,
+                            o,
+                            r,
+                            i,
+                            a,
+                            s = O.sortableInfo.index,
+                            l =
+                              ((t = O),
+                              {
+                                bottom: P(
+                                  (n = window.getComputedStyle(t)).marginBottom,
+                                ),
+                                left: P(n.marginLeft),
+                                right: P(n.marginRight),
+                                top: P(n.marginTop),
+                              }),
+                            c = E.scrollContainer.getBoundingClientRect(),
+                            u = m({collection: T, index: s, node: O});
+                          if (
+                            ((E.node = O),
+                            (E.margin = l),
+                            (E.width = u.width),
+                            (E.height = u.height),
+                            (E.marginOffset = {
+                              x: E.margin.left + E.margin.right,
+                              y: Math.max(E.margin.top, E.margin.bottom),
+                            }),
+                            (E.boundingClientRect = O.getBoundingClientRect()),
+                            (E.containerBoundingRect = c),
+                            (E.index = s),
+                            (E.newIndex = s),
+                            (E.axis = {
+                              x: 0 <= v.indexOf('x'),
+                              y: 0 <= v.indexOf('y'),
+                            }),
+                            (E.offsetEdge = _(O, E.container)),
+                            (E.initialOffset = K(
+                              C
+                                ? R({}, k, {
+                                    pageX: E.boundingClientRect.left,
+                                    pageY: E.boundingClientRect.top,
+                                  })
+                                : k,
+                            )),
+                            (E.initialScroll = {
+                              left: E.scrollContainer.scrollLeft,
+                              top: E.scrollContainer.scrollTop,
+                            }),
+                            (E.initialWindowScroll = {
+                              left: window.pageXOffset,
+                              top: window.pageYOffset,
+                            }),
+                            (E.helper = E.helperContainer.appendChild(
+                              ((r =
+                                'input, textarea, select, canvas, [contenteditable]'),
+                              (i = (o = O).querySelectorAll(r)),
+                              (a = o.cloneNode(!0)),
+                              D(a.querySelectorAll(r)).forEach(function(e, t) {
+                                'file' !== e.type && (e.value = i[t].value),
+                                  'radio' === e.type &&
+                                    e.name &&
+                                    (e.name = '__sortableClone__'.concat(
+                                      e.name,
+                                    )),
+                                  e.tagName === z.Canvas &&
+                                    0 < i[t].width &&
+                                    0 < i[t].height &&
+                                    e.getContext('2d').drawImage(i[t], 0, 0);
+                              }),
+                              a),
+                            )),
+                            A(E.helper, {
+                              boxSizing: 'border-box',
+                              height: ''.concat(E.height, 'px'),
+                              left: ''.concat(
+                                E.boundingClientRect.left - l.left,
+                                'px',
+                              ),
+                              pointerEvents: 'none',
+                              position: 'fixed',
+                              top: ''.concat(
+                                E.boundingClientRect.top - l.top,
+                                'px',
+                              ),
+                              width: ''.concat(E.width, 'px'),
+                            }),
+                            C && E.helper.focus(),
+                            b &&
+                              A((E.sortableGhost = O), {
+                                opacity: 0,
+                                visibility: 'hidden',
+                              }),
+                            (E.minTranslate = {}),
+                            (E.maxTranslate = {}),
+                            C)
+                          ) {
+                            var d = S
+                                ? {
+                                    top: 0,
+                                    left: 0,
+                                    width: E.contentWindow.innerWidth,
+                                    height: E.contentWindow.innerHeight,
+                                  }
+                                : E.containerBoundingRect,
+                              f = d.top,
+                              h = d.left,
+                              p = d.width,
+                              y = f + d.height,
+                              g = h + p;
+                            E.axis.x &&
+                              ((E.minTranslate.x =
+                                h - E.boundingClientRect.left),
+                              (E.maxTranslate.x =
+                                g - (E.boundingClientRect.left + E.width))),
+                              E.axis.y &&
+                                ((E.minTranslate.y =
+                                  f - E.boundingClientRect.top),
+                                (E.maxTranslate.y =
+                                  y - (E.boundingClientRect.top + E.height)));
+                          } else
+                            E.axis.x &&
+                              ((E.minTranslate.x =
+                                (S ? 0 : c.left) -
+                                E.boundingClientRect.left -
+                                E.width / 2),
+                              (E.maxTranslate.x =
+                                (S
+                                  ? E.contentWindow.innerWidth
+                                  : c.left + c.width) -
+                                E.boundingClientRect.left -
+                                E.width / 2)),
+                              E.axis.y &&
+                                ((E.minTranslate.y =
+                                  (S ? 0 : c.top) -
+                                  E.boundingClientRect.top -
+                                  E.height / 2),
+                                (E.maxTranslate.y =
+                                  (S
+                                    ? E.contentWindow.innerHeight
+                                    : c.top + c.height) -
+                                  E.boundingClientRect.top -
+                                  E.height / 2));
+                          x &&
+                            x.split(' ').forEach(function(e) {
+                              return E.helper.classList.add(e);
+                            }),
+                            (E.listenerNode = k.touches ? O : E.contentWindow),
+                            C
+                              ? (E.listenerNode.addEventListener(
+                                  'wheel',
+                                  E.handleKeyEnd,
+                                  !0,
+                                ),
+                                E.listenerNode.addEventListener(
+                                  'mousedown',
+                                  E.handleKeyEnd,
+                                  !0,
+                                ),
+                                E.listenerNode.addEventListener(
+                                  'keydown',
+                                  E.handleKeyDown,
+                                ))
+                              : (N.move.forEach(function(e) {
+                                  return E.listenerNode.addEventListener(
+                                    e,
+                                    E.handleSortMove,
+                                    !1,
+                                  );
+                                }),
+                                N.end.forEach(function(e) {
+                                  return E.listenerNode.addEventListener(
+                                    e,
+                                    E.handleSortEnd,
+                                    !1,
+                                  );
+                                })),
+                            E.setState({sorting: !0, sortingIndex: s}),
+                            w &&
+                              w(
+                                {
+                                  node: O,
+                                  index: s,
+                                  collection: T,
+                                  isKeySorting: C,
+                                },
+                                k,
+                              ),
+                            C && E.keyMove(0);
+                        },
+                        t = E.props,
+                        v = t.axis,
+                        m = t.getHelperDimensions,
+                        x = t.helperClass,
+                        b = t.hideSortableGhost,
+                        n = t.updateBeforeSortStart,
+                        w = t.onSortStart,
+                        S = t.useWindowAsScrollContainer,
+                        O = r.node,
+                        T = r.collection,
+                        C = E.manager.isKeySorting,
+                        o = (function() {
+                          if ('function' == typeof n)
+                            return (
+                              (E._awaitingUpdateBeforeSortStart = !0),
+                              (function(e, t) {
+                                try {
+                                  var n = e();
+                                } catch (e) {
+                                  return t(!0, e);
+                                }
+                                return n && n.then
+                                  ? n.then(t.bind(null, !1), t.bind(null, !0))
+                                  : t(!1, value);
+                              })(
+                                function() {
+                                  var e = O.sortableInfo.index;
+                                  return Promise.resolve(
+                                    n(
+                                      {
+                                        collection: T,
+                                        index: e,
+                                        node: O,
+                                        isKeySorting: C,
+                                      },
+                                      k,
+                                    ),
+                                  ).then(function(e) {
+                                    !1 === e && (I = !0);
+                                  });
+                                },
+                                function(e, t) {
+                                  if (
+                                    ((E._awaitingUpdateBeforeSortStart = !1), e)
+                                  )
+                                    throw t;
+                                  return t;
+                                },
+                              )
+                            );
+                        })();
+                      return o && o.then ? o.then(e) : e(o);
+                    }
+                  })(),
+                );
+              } catch (e) {
+                return Promise.reject(e);
+              }
+            }),
+            c(p(p(E)), 'handleSortMove', function(e) {
+              var t = E.props.onSortMove;
+              'function' == typeof e.preventDefault && e.preventDefault(),
+                E.updateHelperPosition(e),
+                E.animateNodes(),
+                E.autoscroll(),
+                t && t(e);
+            }),
+            c(p(p(E)), 'handleSortEnd', function(e) {
+              var t = E.props,
+                n = t.hideSortableGhost,
+                o = t.onSortEnd,
+                r = E.manager,
+                i = r.active.collection,
+                a = r.isKeySorting,
+                s = E.manager.refs[i];
+              E.listenerNode &&
+                (a
+                  ? (E.listenerNode.removeEventListener(
+                      'wheel',
+                      E.handleKeyEnd,
+                      !0,
+                    ),
+                    E.listenerNode.removeEventListener(
+                      'mousedown',
+                      E.handleKeyEnd,
+                      !0,
+                    ),
+                    E.listenerNode.removeEventListener(
+                      'keydown',
+                      E.handleKeyDown,
+                    ))
+                  : (N.move.forEach(function(e) {
+                      return E.listenerNode.removeEventListener(
+                        e,
+                        E.handleSortMove,
+                      );
+                    }),
+                    N.end.forEach(function(e) {
+                      return E.listenerNode.removeEventListener(
+                        e,
+                        E.handleSortEnd,
+                      );
+                    }))),
+                E.helper.parentNode.removeChild(E.helper),
+                n &&
+                  E.sortableGhost &&
+                  A(E.sortableGhost, {opacity: '', visibility: ''});
+              for (var l = 0, c = s.length; l < c; l++) {
+                var u = s[l],
+                  d = u.node;
+                (u.edgeOffset = null),
+                  M(d, (u.boundingClientRect = null)),
+                  W(d, null),
+                  (u.translate = null);
+              }
+              E.autoScroller.clear(),
+                (E.manager.active = null),
+                (E.manager.isKeySorting = !1),
+                E.setState({sorting: !1, sortingIndex: null}),
+                'function' == typeof o &&
+                  o(
+                    {
+                      collection: i,
+                      newIndex: E.newIndex,
+                      oldIndex: E.index,
+                      isKeySorting: a,
+                    },
+                    e,
+                  ),
+                (E.touched = !1);
+            }),
+            c(p(p(E)), 'autoscroll', function() {
+              var e = E.props.disableAutoscroll,
+                t = E.manager.isKeySorting;
+              if (e) E.autoScroller.clear();
+              else {
+                if (t) {
+                  var n = R({}, E.translate),
+                    o = 0,
+                    r = 0;
+                  return (
+                    E.axis.x &&
+                      ((n.x = Math.min(
+                        E.maxTranslate.x,
+                        Math.max(E.minTranslate.x, E.translate.x),
+                      )),
+                      (o = E.translate.x - n.x)),
+                    E.axis.y &&
+                      ((n.y = Math.min(
+                        E.maxTranslate.y,
+                        Math.max(E.minTranslate.y, E.translate.y),
+                      )),
+                      (r = E.translate.y - n.y)),
+                    (E.translate = n),
+                    M(E.helper, E.translate),
+                    (E.scrollContainer.scrollLeft += o),
+                    void (E.scrollContainer.scrollTop += r)
+                  );
+                }
+                E.autoScroller.update({
+                  height: E.height,
+                  maxTranslate: E.maxTranslate,
+                  minTranslate: E.minTranslate,
+                  translate: E.translate,
+                  width: E.width,
+                });
+              }
+            }),
+            c(p(p(E)), 'onAutoScroll', function(e) {
+              (E.translate.x += e.left),
+                (E.translate.y += e.top),
+                E.animateNodes();
+            }),
+            c(p(p(E)), 'handleKeyDown', function(e) {
+              var t = e.keyCode,
+                n = E.props,
+                o = n.shouldCancelStart,
+                r = n.keyCodes,
+                i = R({}, ee, void 0 === r ? {} : r);
+              (E.manager.active && !E.manager.isKeySorting) ||
+                !(
+                  E.manager.active ||
+                  (i.lift.includes(t) && !o(e) && E.isValidSortingTarget(e))
+                ) ||
+                (e.stopPropagation(),
+                e.preventDefault(),
+                i.lift.includes(t) && !E.manager.active
+                  ? E.keyLift(e)
+                  : i.drop.includes(t) && E.manager.active
+                  ? E.keyDrop(e)
+                  : i.cancel.includes(t)
+                  ? ((E.newIndex = E.manager.active.index), E.keyDrop(e))
+                  : i.up.includes(t)
+                  ? E.keyMove(-1)
+                  : i.down.includes(t) && E.keyMove(1));
+            }),
+            c(p(p(E)), 'keyLift', function(e) {
+              var t = e.target,
+                n = L(t, function(e) {
+                  return null != e.sortableInfo;
+                }).sortableInfo,
+                o = n.index,
+                r = n.collection;
+              (E.initialFocusedNode = t),
+                (E.manager.isKeySorting = !0),
+                (E.manager.active = {index: o, collection: r}),
+                E.handlePress(e);
+            }),
+            c(p(p(E)), 'keyMove', function(e) {
+              var t = E.manager.getOrderedRefs(),
+                n = t[t.length - 1].node.sortableInfo.index,
+                o = E.newIndex + e,
+                r = E.newIndex;
+              if (!(o < 0 || n < o)) {
+                (E.prevIndex = r), (E.newIndex = o);
+                var i,
+                  a,
+                  s,
+                  l =
+                    ((i = E.newIndex),
+                    (a = E.prevIndex),
+                    (s = E.index),
+                    i < s && a < i ? i - 1 : s < i && i < a ? i + 1 : i),
+                  c = t.find(function(e) {
+                    return e.node.sortableInfo.index === l;
+                  }),
+                  u = c.node,
+                  d = E.containerScrollDelta,
+                  f = c.boundingClientRect || H(u, d),
+                  h = c.translate || {x: 0, y: 0},
+                  p = f.top + h.y - d.top,
+                  y = f.left + h.x - d.left,
+                  g = r < o,
+                  v = g && E.axis.x ? u.offsetWidth - E.width : 0,
+                  m = g && E.axis.y ? u.offsetHeight - E.height : 0;
+                E.handleSortMove({
+                  pageX: y + v,
+                  pageY: p + m,
+                  ignoreTransition: 0 === e,
+                });
+              }
+            }),
+            c(p(p(E)), 'keyDrop', function(e) {
+              E.handleSortEnd(e),
+                E.initialFocusedNode && E.initialFocusedNode.focus();
+            }),
+            c(p(p(E)), 'handleKeyEnd', function(e) {
+              E.manager.active && E.keyDrop(e);
+            }),
+            c(p(p(E)), 'isValidSortingTarget', function(e) {
+              var t = E.props.useDragHandle,
+                n = e.target,
+                o = L(n, function(e) {
+                  return null != e.sortableInfo;
+                });
+              return (
+                o &&
+                o.sortableInfo &&
+                !o.sortableInfo.disabled &&
+                (t ? J(n) : n.sortableInfo)
+              );
+            }),
+            w(
+              !((t = e).distance && t.pressDelay),
+              'Attempted to set both `pressDelay` and `distance` on SortableContainer, you may only use one or the other, not both at the same time.',
+            ),
+            (E.manager = new x()),
+            (E.events = {
+              end: E.handleEnd,
+              move: E.handleMove,
+              start: E.handleStart,
+            }),
+            E
+          );
+        }
+        return (
+          m(n, e),
+          f(n, [
+            {
+              key: 'getChildContext',
+              value: function() {
+                return {manager: this.manager};
+              },
+            },
+            {
+              key: 'componentDidMount',
+              value: function() {
+                var n = this,
+                  o = this.props.useWindowAsScrollContainer,
+                  e = this.getContainer();
+                Promise.resolve(e).then(function(e) {
+                  (n.container = e),
+                    (n.document = n.container.ownerDocument || document);
+                  var t =
+                    n.props.contentWindow || n.document.defaultView || window;
+                  (n.contentWindow = 'function' == typeof t ? t() : t),
+                    (n.scrollContainer = o
+                      ? n.document.scrollingElement ||
+                        n.document.documentElement
+                      : G(n.container) || n.container),
+                    (n.autoScroller = new Q(n.scrollContainer, n.onAutoScroll)),
+                    Object.keys(n.events).forEach(function(t) {
+                      return N[t].forEach(function(e) {
+                        return n.container.addEventListener(e, n.events[t], !1);
+                      });
+                    }),
+                    n.container.addEventListener('keydown', n.handleKeyDown);
+                });
+              },
+            },
+            {
+              key: 'componentWillUnmount',
+              value: function() {
+                var n = this;
+                this.helper &&
+                  this.helper.parentNode &&
+                  this.helper.parentNode.removeChild(this.helper),
+                  this.container &&
+                    (Object.keys(this.events).forEach(function(t) {
+                      return N[t].forEach(function(e) {
+                        return n.container.removeEventListener(e, n.events[t]);
+                      });
+                    }),
+                    this.container.removeEventListener(
+                      'keydown',
+                      this.handleKeyDown,
+                    ));
+              },
+            },
+            {
+              key: 'updateHelperPosition',
+              value: function(e) {
+                var t = this.props,
+                  n = t.lockAxis,
+                  o = t.lockOffset,
+                  r = t.lockToContainerEdges,
+                  i = t.transitionDuration,
+                  a = t.keyboardSortingTransitionDuration,
+                  s = void 0 === a ? i : a,
+                  l = this.manager.isKeySorting,
+                  c = e.ignoreTransition,
+                  u = K(e),
+                  d = {
+                    x: u.x - this.initialOffset.x,
+                    y: u.y - this.initialOffset.y,
+                  };
+                if (
+                  ((d.y -= window.pageYOffset - this.initialWindowScroll.top),
+                  (d.x -= window.pageXOffset - this.initialWindowScroll.left),
+                  (this.translate = d),
+                  r)
+                ) {
+                  var f = (function(e) {
+                      var t = e.height,
+                        n = e.width,
+                        o = e.lockOffset,
+                        r = Array.isArray(o) ? o : [o, o];
+                      w(
+                        2 === r.length,
+                        'lockOffset prop of SortableContainer should be a single value or an array of exactly two values. Given %s',
+                        o,
+                      );
+                      var i = b(r, 2),
+                        a = i[0],
+                        s = i[1];
+                      return [
+                        B({height: t, lockOffset: a, width: n}),
+                        B({height: t, lockOffset: s, width: n}),
+                      ];
+                    })({height: this.height, lockOffset: o, width: this.width}),
+                    h = b(f, 2),
+                    p = h[0],
+                    y = h[1],
+                    g = this.width / 2 - p.x,
+                    v = this.height / 2 - p.y,
+                    m = this.width / 2 - y.x,
+                    x = this.height / 2 - y.y;
+                  (d.x = E(
+                    this.minTranslate.x + g,
+                    this.maxTranslate.x - m,
+                    d.x,
+                  )),
+                    (d.y = E(
+                      this.minTranslate.y + v,
+                      this.maxTranslate.y - x,
+                      d.y,
+                    ));
+                }
+                'x' === n ? (d.y = 0) : 'y' === n && (d.x = 0),
+                  l && s && !c && W(this.helper, s),
+                  M(this.helper, d);
+              },
+            },
+            {
+              key: 'animateNodes',
+              value: function() {
+                var e = this.props,
+                  t = e.transitionDuration,
+                  n = e.hideSortableGhost,
+                  o = e.onSortOver,
+                  r = this.containerScrollDelta,
+                  i = this.windowScrollDelta,
+                  a = this.manager.getOrderedRefs(),
+                  s = this.offsetEdge.left + this.translate.x + r.left,
+                  l = this.offsetEdge.top + this.translate.y + r.top,
+                  c = this.manager.isKeySorting,
+                  u = this.newIndex;
+                this.newIndex = null;
+                for (var d = 0, f = a.length; d < f; d++) {
+                  var h = a[d].node,
+                    p = h.sortableInfo.index,
+                    y = h.offsetWidth,
+                    g = h.offsetHeight,
+                    v = this.height > g ? g / 2 : this.height / 2,
+                    m = this.width > y ? y / 2 : this.width / 2,
+                    x = c && p > this.index && p <= u,
+                    b = c && p < this.index && u <= p,
+                    w = {x: 0, y: 0},
+                    S = a[d].edgeOffset;
+                  S ||
+                    ((S = _(h, this.container)),
+                    (a[d].edgeOffset = S),
+                    c && (a[d].boundingClientRect = H(h, r)));
+                  var O = d < a.length - 1 && a[d + 1],
+                    T = 0 < d && a[d - 1];
+                  O &&
+                    !O.edgeOffset &&
+                    ((O.edgeOffset = _(O.node, this.container)),
+                    c && (O.boundingClientRect = H(O.node, r))),
+                    p !== this.index
+                      ? (t && W(h, t),
+                        this.axis.x
+                          ? this.axis.y
+                            ? b ||
+                              (p < this.index &&
+                                ((s + i.left - m <= S.left &&
+                                  l + i.top <= S.top + v) ||
+                                  l + i.top + v <= S.top))
+                              ? ((w.x = this.width + this.marginOffset.x),
+                                S.left + w.x >
+                                  this.containerBoundingRect.width - m &&
+                                  O &&
+                                  ((w.x = O.edgeOffset.left - S.left),
+                                  (w.y = O.edgeOffset.top - S.top)),
+                                null === this.newIndex && (this.newIndex = p))
+                              : (x ||
+                                  (p > this.index &&
+                                    ((s + i.left + m >= S.left &&
+                                      l + i.top + v >= S.top) ||
+                                      l + i.top + v >= S.top + g))) &&
+                                ((w.x = -(this.width + this.marginOffset.x)),
+                                S.left + w.x <
+                                  this.containerBoundingRect.left + m &&
+                                  T &&
+                                  ((w.x = T.edgeOffset.left - S.left),
+                                  (w.y = T.edgeOffset.top - S.top)),
+                                (this.newIndex = p))
+                            : x || (p > this.index && s + i.left + m >= S.left)
+                            ? ((w.x = -(this.width + this.marginOffset.x)),
+                              (this.newIndex = p))
+                            : (b ||
+                                (p < this.index && s + i.left <= S.left + m)) &&
+                              ((w.x = this.width + this.marginOffset.x),
+                              null == this.newIndex && (this.newIndex = p))
+                          : this.axis.y &&
+                            (x || (p > this.index && l + i.top + v >= S.top)
+                              ? ((w.y = -(this.height + this.marginOffset.y)),
+                                (this.newIndex = p))
+                              : (b ||
+                                  (p < this.index && l + i.top <= S.top + v)) &&
+                                ((w.y = this.height + this.marginOffset.y),
+                                null == this.newIndex && (this.newIndex = p))),
+                        M(h, w),
+                        (a[d].translate = w))
+                      : n &&
+                        A((this.sortableGhost = h), {
+                          opacity: 0,
+                          visibility: 'hidden',
+                        });
+                }
+                null == this.newIndex && (this.newIndex = this.index),
+                  c && (this.newIndex = u);
+                var C = c ? this.prevIndex : u;
+                o &&
+                  this.newIndex !== C &&
+                  o({
+                    collection: this.manager.active.collection,
+                    index: this.index,
+                    newIndex: this.newIndex,
+                    oldIndex: C,
+                    isKeySorting: c,
+                  });
+              },
+            },
+            {
+              key: 'getWrappedInstance',
+              value: function() {
+                return (
+                  w(
+                    o.withRef,
+                    'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableContainer() call',
+                  ),
+                  this.refs.wrappedInstance
+                );
+              },
+            },
+            {
+              key: 'getContainer',
+              value: function() {
+                var e = this.props.getContainer;
+                return 'function' != typeof e
+                  ? a.findDOMNode(this)
+                  : e(o.withRef ? this.getWrappedInstance() : void 0);
+              },
+            },
+            {
+              key: 'render',
+              value: function() {
+                var e = o.withRef ? 'wrappedInstance' : null;
+                return r.createElement(t, s({ref: e}, k(this.props, ne)));
+              },
+            },
+            {
+              key: 'helperContainer',
+              get: function() {
+                var e = this.props.helperContainer;
+                return 'function' == typeof e
+                  ? e()
+                  : this.props.helperContainer || this.document.body;
+              },
+            },
+            {
+              key: 'containerScrollDelta',
+              get: function() {
+                return this.props.useWindowAsScrollContainer
+                  ? {left: 0, top: 0}
+                  : {
+                      left:
+                        this.scrollContainer.scrollLeft -
+                        this.initialScroll.left,
+                      top:
+                        this.scrollContainer.scrollTop - this.initialScroll.top,
+                    };
+              },
+            },
+            {
+              key: 'windowScrollDelta',
+              get: function() {
+                return {
+                  left:
+                    this.contentWindow.pageXOffset -
+                    this.initialWindowScroll.left,
+                  top:
+                    this.contentWindow.pageYOffset -
+                    this.initialWindowScroll.top,
+                };
+              },
+            },
+          ]),
+          n
+        );
+      })(r.Component)),
+      c(e, 'displayName', j('sortableList', t)),
+      c(e, 'defaultProps', te),
+      c(e, 'propTypes', Z),
+      c(e, 'childContextTypes', {manager: i.object.isRequired}),
+      n
+    );
+  }
+  var re = {
+      index: i.number.isRequired,
+      collection: i.oneOfType([i.number, i.string]),
+      disabled: i.bool,
+    },
+    ie = Object.keys(re);
+  function ae(n) {
+    var e,
+      t,
+      o =
+        1 < arguments.length && void 0 !== arguments[1]
+          ? arguments[1]
+          : {withRef: !1};
+    return (
+      (t = e = (function(e) {
+        function t() {
+          return u(this, t), y(this, g(t).apply(this, arguments));
+        }
+        return (
+          m(t, e),
+          f(t, [
+            {
+              key: 'componentDidMount',
+              value: function() {
+                this.register();
+              },
+            },
+            {
+              key: 'componentDidUpdate',
+              value: function(e) {
+                this.node &&
+                  (e.index !== this.props.index &&
+                    (this.node.sortableInfo.index = this.props.index),
+                  e.disabled !== this.props.disabled &&
+                    (this.node.sortableInfo.disabled = this.props.disabled)),
+                  e.collection !== this.props.collection &&
+                    (this.unregister(e.collection), this.register());
+              },
+            },
+            {
+              key: 'componentWillUnmount',
+              value: function() {
+                this.unregister();
+              },
+            },
+            {
+              key: 'register',
+              value: function() {
+                var e = this.props,
+                  t = e.collection,
+                  n = e.disabled,
+                  o = e.index,
+                  r = a.findDOMNode(this);
+                (r.sortableInfo = {
+                  collection: t,
+                  disabled: n,
+                  index: o,
+                  manager: this.context.manager,
+                }),
+                  (this.node = r),
+                  (this.ref = {node: r}),
+                  this.context.manager.add(t, this.ref);
+              },
+            },
+            {
+              key: 'unregister',
+              value: function() {
+                var e =
+                  0 < arguments.length && void 0 !== arguments[0]
+                    ? arguments[0]
+                    : this.props.collection;
+                this.context.manager.remove(e, this.ref);
+              },
+            },
+            {
+              key: 'getWrappedInstance',
+              value: function() {
+                return (
+                  w(
+                    o.withRef,
+                    'To access the wrapped instance, you need to pass in {withRef: true} as the second argument of the SortableElement() call',
+                  ),
+                  this.refs.wrappedInstance
+                );
+              },
+            },
+            {
+              key: 'render',
+              value: function() {
+                var e = o.withRef ? 'wrappedInstance' : null;
+                return r.createElement(n, s({ref: e}, k(this.props, ie)));
+              },
+            },
+          ]),
+          t
+        );
+      })(r.Component)),
+      c(e, 'displayName', j('sortableElement', n)),
+      c(e, 'contextTypes', {manager: i.object.isRequired}),
+      c(e, 'propTypes', re),
+      c(e, 'defaultProps', {collection: 0}),
+      t
+    );
+  }
+  (e.SortableContainer = oe),
+    (e.sortableContainer = oe),
+    (e.SortableElement = ae),
+    (e.sortableElement = ae),
+    (e.SortableHandle = $),
+    (e.sortableHandle = $),
+    (e.arrayMove = function(e, t, n) {
+      return (
+        (e = e.slice()).splice(n < 0 ? e.length + n : n, 0, e.splice(t, 1)[0]),
+        e
+      );
+    }),
+    Object.defineProperty(e, '__esModule', {value: !0});
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",
@@ -80,7 +80,7 @@
     "html-webpack-plugin": "^2.16.1",
     "husky": "^3.0.4",
     "lodash": "^4.12.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.13.0",
     "postcss": "^7.0.7",
     "postcss-loader": "^3.0.0",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-hoc",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Set of higher-order components to turn any list into a sortable, touch-friendly, animated list",
   "author": {
     "name": "Clauderic Demers",

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -248,10 +248,12 @@ export default function sortableContainer(
 
           try {
             const {index} = node.sortableInfo;
-            await updateBeforeSortStart(
+            const result = await updateBeforeSortStart(
               {collection, index, node, isKeySorting},
               event,
             );
+            // If `updateBeforeSortStart` resolves to false, cancel drag before it starts
+            if (result === false) return;
           } finally {
             this._awaitingUpdateBeforeSortStart = false;
           }


### PR DESCRIPTION
Cancel drag if updateBeforeSortStart resolves to false

Changed `handlePress` to enable drag cancellation before it starts if `updateBeforeSortStart` resolves to false. It should yield `false` specifically and not just any falsy value, since this change would affect the flow, the idea is not to change how it is currently working if resolving to undefined/null or other non-false falsy values.

Another less disrupting way of providing this feature might allowing for `shouldCancelStart` async check.

The idea is to be able to cancel the entire drag event if something happens during the async execution of `updateBeforeSortStart`. If this approach is no good, other suggestions to achieve would be much appreciated!