### PR TITLE
Cancel drag if updateBeforeSortStart resolves to false

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -248,10 +248,12 @@ export default function sortableContainer(
 
           try {
             const {index} = node.sortableInfo;
-            await updateBeforeSortStart(
+            const result = await updateBeforeSortStart(
               {collection, index, node, isKeySorting},
               event,
             );
+            // If `updateBeforeSortStart` resolves to false, cancel sort before it starts
+            if (result === false) return;
           } finally {
             this._awaitingUpdateBeforeSortStart = false;
           }


### PR DESCRIPTION
Cancel drag if updateBeforeSortStart resolves to false

Changed handlePress to enable drag cancellation before it starts if updateBeforeSortStart resolves to false. It should yield false specifically and not just any falsy value, since this change would affect the flow, the idea is not to change how it is currently working if resolving to undefined/null or other non-false falsy values.

Another less disrupting way of providing this feature might allowing for shouldCancelStart async check.

The idea is to be able to cancel the entire drag event if something happens during the async execution of updateBeforeSortStart. If this approach is no good, other suggestions to achieve would be much appreciated!