### PR TITLE
Fixed layout thrashing - performance issue

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -516,7 +516,7 @@ storiesOf('General | Layout / Grid', module).add('Basic setup', () => {
       <ListWrapper
         component={SortableList}
         axis={'xy'}
-        items={getItems(10, 110)}
+        items={getItems(400, 110)}
         helperClass={style.stylizedHelper}
         className={classNames(style.list, style.stylizedList, style.grid)}
         itemClass={classNames(style.stylizedItem, style.gridItem)}

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -516,7 +516,7 @@ storiesOf('General | Layout / Grid', module).add('Basic setup', () => {
       <ListWrapper
         component={SortableList}
         axis={'xy'}
-        items={getItems(400, 110)}
+        items={getItems(50, 110)}
         helperClass={style.stylizedHelper}
         className={classNames(style.list, style.stylizedList, style.grid)}
         itemClass={classNames(style.stylizedItem, style.gridItem)}

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -627,7 +627,7 @@ export default function sortableContainer(
       const prevIndex = this.newIndex;
       this.newIndex = null;
 
-      const nodesTransitionStyle = {};
+      const nodesStyle = {};
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const {index} = node.sortableInfo;
@@ -799,19 +799,19 @@ export default function sortableContainer(
           }
         }
 
-        nodesTransitionStyle[i] = setTranslate3d(translate);
+        nodesStyle[i] = setTranslate3d(translate);
       }
 
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {transitionDuration} = this.props;
         if (transitionDuration) {
-          nodesTransitionStyle[i] = {
-            ...nodesTransitionStyle[i],
+          nodesStyle[i] = {
+            ...nodesStyle[i],
             ...setTransitionDuration(transitionDuration),
           };
         }
 
-        setInlineStyles(nodes[i].node, nodesTransitionStyle[i]);
+        setInlineStyles(nodes[i].node, nodesStyle[i]);
       }
 
       if (this.newIndex == null) {

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -509,8 +509,10 @@ export default function sortableContainer(
         node.boundingClientRect = null;
 
         // Remove the transforms / transitions
-        setTranslate3d(el, null);
-        setTransitionDuration(el, null);
+        setInlineStyles(el, {
+          ...setTranslate3d(null),
+          ...setTransitionDuration(null),
+        });
         node.translate = null;
       }
 
@@ -602,14 +604,17 @@ export default function sortableContainer(
         keyboardSortingTransitionDuration &&
         !ignoreTransition
       ) {
-        setTransitionDuration(this.helper, keyboardSortingTransitionDuration);
+        setInlineStyles(
+          this.helper,
+          setTransitionDuration(keyboardSortingTransitionDuration),
+        );
       }
 
-      setTranslate3d(this.helper, translate);
+      setInlineStyles(this.helper, setTranslate3d(translate));
     }
 
     animateNodes() {
-      const {transitionDuration, hideSortableGhost, onSortOver} = this.props;
+      const {hideSortableGhost, onSortOver} = this.props;
       const {containerScrollDelta, windowScrollDelta} = this;
       const nodes = this.manager.getOrderedRefs();
       const sortingOffset = {
@@ -622,6 +627,7 @@ export default function sortableContainer(
       const prevIndex = this.newIndex;
       this.newIndex = null;
 
+      const nodesTransitionStyle = {};
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
         const {index} = node.sortableInfo;
@@ -689,10 +695,6 @@ export default function sortableContainer(
             });
           }
           continue;
-        }
-
-        if (transitionDuration) {
-          setTransitionDuration(node, transitionDuration);
         }
 
         if (this.axis.x) {
@@ -797,8 +799,19 @@ export default function sortableContainer(
           }
         }
 
-        setTranslate3d(node, translate);
-        nodes[i].translate = translate;
+        nodesTransitionStyle[i] = setTranslate3d(translate);
+      }
+
+      for (let i = 0, len = nodes.length; i < len; i++) {
+        const {transitionDuration} = this.props;
+        if (transitionDuration) {
+          nodesTransitionStyle[i] = {
+            ...nodesTransitionStyle[i],
+            ...setTransitionDuration(transitionDuration),
+          };
+        }
+
+        setInlineStyles(nodes[i].node, nodesTransitionStyle[i]);
       }
 
       if (this.newIndex == null) {
@@ -853,7 +866,7 @@ export default function sortableContainer(
         }
 
         this.translate = translate;
-        setTranslate3d(this.helper, this.translate);
+        setInlineStyles(this.helper, setTranslate3d(this.translate));
         this.scrollContainer.scrollLeft += scrollX;
         this.scrollContainer.scrollTop += scrollY;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,14 +68,20 @@ export function setInlineStyles(node, styles) {
   });
 }
 
-export function setTranslate3d(node, translate) {
-  node.style[`${vendorPrefix}Transform`] =
-    translate == null ? '' : `translate3d(${translate.x}px,${translate.y}px,0)`;
+export function setTranslate3d(translate) {
+  return {
+    [`${vendorPrefix}Transform`]:
+      translate == null
+        ? ''
+        : `translate3d(${translate.x}px,${translate.y}px,0)`,
+  };
 }
 
-export function setTransitionDuration(node, duration) {
-  node.style[`${vendorPrefix}TransitionDuration`] =
-    duration == null ? '' : `${duration}ms`;
+export function setTransitionDuration(duration) {
+  return {
+    [`${vendorPrefix}TransitionDuration`]:
+      duration == null ? '' : `${duration}ms`,
+  };
 }
 
 export function closest(el, fn) {


### PR DESCRIPTION
**Problem**:
There is huge performance problem while handling mouse move first time. It freeze 1-2s before moving when sortable element count increased. If sortable element has more complicated dom tree it getting even worse.

**What cause the problem**
While handling first mousemove there is for loop applying style `transform: translate3d(0,0,0)` for each node. On the next iteration of the loop, the browser has to account for the fact that styles have changed since offsetWidth was last requested (in the previous iteration), and so it must apply the style changes, and run layout. This will happen on every single iteration!.

![slower](https://user-images.githubusercontent.com/18191422/70378608-cb222980-193b-11ea-83c7-e735012b9624.png)

**Solution**
Moving applying style outside of calcuation loop after all calculation done.
![faster](https://user-images.githubusercontent.com/18191422/70378782-eb52e800-193d-11ea-8df9-f2164e614d93.png)





