### PR TITLE
Fixed getScrollingParent and isScrollable when used in iframes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -240,17 +240,16 @@ export function getLockPixelOffsets({height, width, lockOffset}) {
 }
 
 function isScrollable(el) {
-  const computedStyle = window.getComputedStyle(el);
-  const overflowRegex = /(auto|scroll)/;
-  const properties = ['overflow', 'overflowX', 'overflowY'];
-
-  return properties.find((property) =>
-    overflowRegex.test(computedStyle[property]),
-  );
+  var computedStyle = el.ownerDocument.defaultView.getComputedStyle(el);
+  var overflowRegex = /(auto|scroll)/;
+  var properties = ['overflow', 'overflowX', 'overflowY'];
+  return properties.find(function (property) {
+    return overflowRegex.test(computedStyle[property]);
+  });
 }
 
-export function getScrollingParent(el) {
-  if (!(el instanceof HTMLElement)) {
+function getScrollingParent(el) {
+  if (!(el instanceof el.ownerDocument.defaultView.HTMLElement)) {
     return null;
   } else if (isScrollable(el)) {
     return el;

--- a/src/utils.js
+++ b/src/utils.js
@@ -243,10 +243,10 @@ function isScrollable(el) {
   const computedStyle = el.ownerDocument.defaultView.getComputedStyle(el);
   const overflowRegex = /(auto|scroll)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
-  
-  return properties.find(function (property) {
-    return overflowRegex.test(computedStyle[property]);
-  });
+
+  return properties.find((property) =>
+    overflowRegex.test(computedStyle[property]),
+  );
 }
 
 export function getScrollingParent(el) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,9 +240,10 @@ export function getLockPixelOffsets({height, width, lockOffset}) {
 }
 
 function isScrollable(el) {
-  var computedStyle = el.ownerDocument.defaultView.getComputedStyle(el);
-  var overflowRegex = /(auto|scroll)/;
-  var properties = ['overflow', 'overflowX', 'overflowY'];
+  const computedStyle = el.ownerDocument.defaultView.getComputedStyle(el);
+  const overflowRegex = /(auto|scroll)/;
+  const properties = ['overflow', 'overflowX', 'overflowY'];
+  
   return properties.find(function (property) {
     return overflowRegex.test(computedStyle[property]);
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -248,7 +248,7 @@ function isScrollable(el) {
   });
 }
 
-function getScrollingParent(el) {
+export function getScrollingParent(el) {
   if (!(el instanceof el.ownerDocument.defaultView.HTMLElement)) {
     return null;
   } else if (isScrollable(el)) {


### PR DESCRIPTION
When using `srcDoc` on an `iframe`, you're pushing HTML in from your parent `window` into the `iframe` directly. Because of this, we need to reference the element's instances of `HTMLElement` and `window` to ensure we're using the right values.

For instance, an element made in an iframe has a different `HTMLElement` class instance than the one in the parent document which this JavaScript was imported.