### PR TITLE
Move to babel-runtime to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     }
   },
   "dependencies": {
-    "@babel/runtime": "^7.2.0",
     "invariant": "^2.2.4",
     "prop-types": "^15.5.7"
   },
   "peerDependencies": {
+    "@babel/runtime": "^7.2.0",
     "prop-types": "^15.5.7",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,7 +1149,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
   integrity sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==


### PR DESCRIPTION
**Problem:** `@babel/runtime` set as a `dependency` forces our app to download ~2KB of additional data, despite the fact that we already have a version of that package.

**Solution:** We realized that if we move this package to be a `peerDependency` it will allow to opt out of downloading that specific version of the package if other versions exist; therefore saving ~2KB.

This resolves issue [683](https://github.com/clauderic/react-sortable-hoc/issues/683).