### PR TITLE
Fix shift to next row calculation

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -727,7 +727,7 @@ export default function sortableContainer(
               translate.x = this.width + this.marginOffset.x;
               if (
                 edgeOffset.left + translate.x >
-                this.containerBoundingRect.width - offset.width
+                this.containerBoundingRect.width - offset.width * 2
               ) {
                 // If it moves passed the right bounds, then animate it to the first position of the next row.
                 // We just use the offset of the next node to calculate where to move, because that node's original position


### PR DESCRIPTION
This PR fixes the issue that is happening in this demo (http://clauderic.github.io/react-sortable-hoc/#/basic-configuration/grid?_k=8abqva)

and demonstrated in this issue #626 
![image](https://user-images.githubusercontent.com/22530892/67627610-541e4f00-f82d-11e9-90db-8322523b81c0.gif)

The calculation that was made to determine if a node has moved past the right bounds is using `offset.width` which is only half of the width of the node. This means, if there are more than half of the width of empty space on the right of the container, the node will shift out of the Grid like the image above.

resolves #626, resolves #551, resolves #523, resolves #689 
