### PR TITLE
Locked items

### DIFF
--- a/src/.stories/Storybook.scss
+++ b/src/.stories/Storybook.scss
@@ -71,6 +71,10 @@ $focusedOutlineColor: #4c9ffe;
   opacity: 0.5;
 }
 
+.locked {
+  cursor: default;
+}
+
 // Drag handle
 .handleWrapper {
   width: 18px;

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -33,13 +33,10 @@ const arrayMoveWithLockedItems = (array, from, to, lockedIndices = []) => {
     ? lockedIndices.filter((index) => index > from && index < to)
     : lockedIndices.filter((index) => index < from && index > to);
 
-  const _from = isForward ? from : from - lockedIndicesInRange.length;
-  const _to = isForward ? to - lockedIndicesInRange.length : to;
-
   const arr = arrayMove(
     array.filter((_, index) => !lockedIndicesInRange.includes(index)),
-    _from,
-    _to,
+    isForward ? from : from - lockedIndicesInRange.length,
+    isForward ? to - lockedIndicesInRange.length : to,
   );
 
   lockedIndicesInRange.forEach((index) => {

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -37,6 +37,11 @@ import {
   defaultKeyCodes,
 } from './props';
 
+const DIRECTION = {
+  FORWARD: 'forward',
+  BACKWARD: 'backward',
+};
+
 export default function sortableContainer(
   WrappedComponent,
   config = {withRef: false},
@@ -143,9 +148,9 @@ export default function sortableContainer(
         !this.state.sorting
       ) {
         const {useDragHandle} = this.props;
-        const {index, collection, disabled} = node.sortableInfo;
+        const {index, collection, disabled, locked} = node.sortableInfo;
 
-        if (disabled) {
+        if (disabled || locked) {
           return;
         }
 
@@ -636,9 +641,39 @@ export default function sortableContainer(
       const prevIndex = this.newIndex;
       this.newIndex = null;
 
+      // Given an item index and a direction within the list in which it should be
+      // moved, find the next valid index at which it can be positioned.
+      const findNextSortIndex = (
+        index,
+        direction,
+        isAllowedToMoveToNode = ({node}) => !node.sortableInfo.locked,
+      ) => {
+        let i = index + 1;
+        let loop = () => i < nodes.length;
+        let increment = () => (i += 1);
+
+        if (direction === DIRECTION.BACKWARD) {
+          i = index - 1;
+          loop = () => i >= 0;
+          increment = () => (i -= 1);
+        }
+
+        while (loop()) {
+          if (isAllowedToMoveToNode(nodes[i])) {
+            return i;
+          }
+          increment();
+        }
+      };
+
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
-        const {index} = node.sortableInfo;
+        const {index, locked} = node.sortableInfo;
+
+        if (locked) {
+          continue;
+        }
+
         const width = node.offsetWidth;
         const height = node.offsetHeight;
         const offset = {
@@ -709,6 +744,12 @@ export default function sortableContainer(
           setTransitionDuration(node, transitionDuration);
         }
 
+        const getNextEdgeOffset = (direction) => {
+          const nextSortIndex = findNextSortIndex(i, direction);
+          const nextSortIndexOwner = nodes[nextSortIndex];
+          return getEdgeOffset(nextSortIndexOwner.node, this.container);
+        };
+
         if (this.axis.x) {
           if (this.axis.y) {
             // Calculations for a grid setup
@@ -722,21 +763,10 @@ export default function sortableContainer(
                   sortingOffset.top + windowScrollDelta.top + offset.height <=
                     edgeOffset.top))
             ) {
-              // If the current node is to the left on the same row, or above the node that's being dragged
-              // then move it to the right
-              translate.x = this.width + this.marginOffset.x;
-              if (
-                edgeOffset.left + translate.x >
-                this.containerBoundingRect.width - offset.width
-              ) {
-                // If it moves passed the right bounds, then animate it to the first position of the next row.
-                // We just use the offset of the next node to calculate where to move, because that node's original position
-                // is exactly where we want to go
-                if (nextNode) {
-                  translate.x = nextNode.edgeOffset.left - edgeOffset.left;
-                  translate.y = nextNode.edgeOffset.top - edgeOffset.top;
-                }
-              }
+              const nextEdgeOffset = getNextEdgeOffset(DIRECTION.FORWARD);
+              translate.x = nextEdgeOffset.left - edgeOffset.left;
+              translate.y = nextEdgeOffset.top - edgeOffset.top;
+
               if (this.newIndex === null) {
                 this.newIndex = index;
               }
@@ -750,21 +780,9 @@ export default function sortableContainer(
                   sortingOffset.top + windowScrollDelta.top + offset.height >=
                     edgeOffset.top + height))
             ) {
-              // If the current node is to the right on the same row, or below the node that's being dragged
-              // then move it to the left
-              translate.x = -(this.width + this.marginOffset.x);
-              if (
-                edgeOffset.left + translate.x <
-                this.containerBoundingRect.left + offset.width
-              ) {
-                // If it moves passed the left bounds, then animate it to the last position of the previous row.
-                // We just use the offset of the previous node to calculate where to move, because that node's original position
-                // is exactly where we want to go
-                if (prevNode) {
-                  translate.x = prevNode.edgeOffset.left - edgeOffset.left;
-                  translate.y = prevNode.edgeOffset.top - edgeOffset.top;
-                }
-              }
+              const nextEdgeOffset = getNextEdgeOffset(DIRECTION.BACKWARD);
+              translate.x = nextEdgeOffset.left - edgeOffset.left;
+              translate.y = nextEdgeOffset.top - edgeOffset.top;
               this.newIndex = index;
             }
           } else {
@@ -774,7 +792,8 @@ export default function sortableContainer(
                 sortingOffset.left + windowScrollDelta.left + offset.width >=
                   edgeOffset.left)
             ) {
-              translate.x = -(this.width + this.marginOffset.x);
+              const nextEdgeOffset = getNextEdgeOffset(DIRECTION.BACKWARD);
+              translate.x = nextEdgeOffset.left - edgeOffset.left;
               this.newIndex = index;
             } else if (
               mustShiftForward ||
@@ -782,8 +801,8 @@ export default function sortableContainer(
                 sortingOffset.left + windowScrollDelta.left <=
                   edgeOffset.left + offset.width)
             ) {
-              translate.x = this.width + this.marginOffset.x;
-
+              const nextEdgeOffset = getNextEdgeOffset(DIRECTION.FORWARD);
+              translate.x = nextEdgeOffset.left - edgeOffset.left;
               if (this.newIndex == null) {
                 this.newIndex = index;
               }
@@ -796,7 +815,9 @@ export default function sortableContainer(
               sortingOffset.top + windowScrollDelta.top + offset.height >=
                 edgeOffset.top)
           ) {
-            translate.y = -(this.height + this.marginOffset.y);
+            const nextEdgeOffset = getNextEdgeOffset(DIRECTION.BACKWARD);
+
+            translate.y = nextEdgeOffset.top - edgeOffset.top;
             this.newIndex = index;
           } else if (
             mustShiftForward ||
@@ -804,7 +825,9 @@ export default function sortableContainer(
               sortingOffset.top + windowScrollDelta.top <=
                 edgeOffset.top + offset.height)
           ) {
-            translate.y = this.height + this.marginOffset.y;
+            const nextEdgeOffset = getNextEdgeOffset(DIRECTION.FORWARD);
+
+            translate.y = nextEdgeOffset.top - edgeOffset.top;
             if (this.newIndex == null) {
               this.newIndex = index;
             }

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -641,12 +641,16 @@ export default function sortableContainer(
       const prevIndex = this.newIndex;
       this.newIndex = null;
 
+      // Returns whether a node location is a valid location for another node
+      // to be moved into
+      const isAllowedToMoveToNode = ({node}) => !node.sortableInfo.locked;
+
       // Given an item index and a direction within the list in which it should be
       // moved, find the next valid index at which it can be positioned.
       const findNextSortIndex = (
         index,
         direction,
-        isAllowedToMoveToNode = ({node}) => !node.sortableInfo.locked,
+        predicate = isAllowedToMoveToNode,
       ) => {
         let i = index + 1;
         let loop = () => i < nodes.length;
@@ -659,7 +663,7 @@ export default function sortableContainer(
         }
 
         while (loop()) {
-          if (isAllowedToMoveToNode(nodes[i])) {
+          if (predicate(nodes[i])) {
             return i;
           }
           increment();
@@ -668,9 +672,9 @@ export default function sortableContainer(
 
       for (let i = 0, len = nodes.length; i < len; i++) {
         const {node} = nodes[i];
-        const {index, locked} = node.sortableInfo;
+        const {index} = node.sortableInfo;
 
-        if (locked) {
+        if (!isAllowedToMoveToNode(nodes[i])) {
           continue;
         }
 

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -712,7 +712,6 @@ export default function sortableContainer(
 
         // Get a reference to the next and previous node
         const nextNode = i < nodes.length - 1 && nodes[i + 1];
-        const prevNode = i > 0 && nodes[i - 1];
 
         // Also cache the next node's edge offset if needed.
         // We need this for calculating the animation in a grid setup

--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -9,6 +9,7 @@ const propTypes = {
   index: PropTypes.number.isRequired,
   collection: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   disabled: PropTypes.bool,
+  locked: PropTypes.bool,
 };
 
 const omittedProps = Object.keys(propTypes);
@@ -46,6 +47,10 @@ export default function sortableElement(
         if (prevProps.disabled !== this.props.disabled) {
           this.node.sortableInfo.disabled = this.props.disabled;
         }
+
+        if (prevProps.locked !== this.props.locked) {
+          this.node.sortableInfo.locked = this.props.locked;
+        }
       }
 
       if (prevProps.collection !== this.props.collection) {
@@ -59,13 +64,14 @@ export default function sortableElement(
     }
 
     register() {
-      const {collection, disabled, index} = this.props;
+      const {collection, disabled, locked, index} = this.props;
       const node = findDOMNode(this);
 
       node.sortableInfo = {
         collection,
         disabled,
         index,
+        locked,
         manager: this.context.manager,
       };
 


### PR DESCRIPTION
This relates to the issue at: https://github.com/clauderic/react-sortable-hoc/issues/648

### What does this do?
It implements the ability for configuring "locked items". Locked items are items that are not draggable, and also do not move when an item is dragged over them.

I implemented this as `lockedItems` distinct from disabled items - given potential for wanting elements that are fixed in their position, but not necessarily in a "disabled" visual state. To have both disabled and locked state items, one would pass the distinct disabled and locked props.

### How did I test this?
I implemented stories for horizontal, vertical, and grid layouts, and dragged items around in different scenarios and velocities. I was unable to find an existing testing setup to write additional tests - please let me know if there is something I overlooked in this regard.

A video of the interaction and stories this PR introduces can be found at:
https://drive.google.com/file/d/1sS2vh161ai9IHaIRDEshsAyicWkdFG3h/view?usp=sharing