### PR TITLE
fix: check if event is cancelable before calling preventDefault

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -452,7 +452,7 @@ export default function sortableContainer(
       const {onSortMove} = this.props;
 
       // Prevent scrolling on mobile
-      if (typeof event.preventDefault === 'function') {
+      if (typeof event.preventDefault === 'function' && event.cancelable) {
         event.preventDefault();
       }
 


### PR DESCRIPTION
Fix https://github.com/clauderic/react-sortable-hoc/issues/751


Avoid issues on mobile where an error is triggered when calling
preventDefault on an event that cannot be cancelled.

Fix these kind of error messages:

> [Intervention] Ignored attempt to cancel a touchmove event with
cancelable=false, for example because scrolling is in progress and
cannot be interrupted.

https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable