### PR TITLE
fix: can't find key 'disableAutoscroll' in SortableContainerProps

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,6 +88,7 @@ export interface SortableContainerProps {
   getContainer?: ContainerGetter;
   getHelperDimensions?: (sort: SortStart) => Dimensions;
   helperContainer?: HTMLElement | HelperContainerGetter;
+  disableAutoscroll?: boolean;
 }
 
 export interface SortableElementProps {


### PR DESCRIPTION
fix #666

Solves the issue `disableAutoscroll` does not exist on type `SortableContainerProps`