### PR TITLE
fix: Cannot work well in mobile devices, when using useWindowAsScrollContainer

### DIFF
--- a/src/AutoScroller/index.js
+++ b/src/AutoScroller/index.js
@@ -13,7 +13,7 @@ export default class AutoScroller {
     this.interval = null;
   }
 
-  update({translate, minTranslate, maxTranslate, width, height}) {
+  update({translate, minTranslate, maxTranslate, width, height, useWindowAsScrollContainer}) {
     const direction = {
       x: 0,
       y: 0,
@@ -36,8 +36,10 @@ export default class AutoScroller {
       clientWidth,
     } = this.container;
 
+    const windowHeight = window.innerHeight;
+
     const isTop = scrollTop === 0;
-    const isBottom = scrollHeight - scrollTop - clientHeight === 0;
+    const isBottom = scrollHeight - scrollTop - (useWindowAsScrollContainer ? windowHeight : clientHeight) === 0;
     const isLeft = scrollLeft === 0;
     const isRight = scrollWidth - scrollLeft - clientWidth === 0;
 

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -839,7 +839,7 @@ export default function sortableContainer(
     }
 
     autoscroll = () => {
-      const {disableAutoscroll} = this.props;
+      const {disableAutoscroll,useWindowAsScrollContainer} = this.props;
       const {isKeySorting} = this.manager;
 
       if (disableAutoscroll) {
@@ -882,6 +882,7 @@ export default function sortableContainer(
         minTranslate: this.minTranslate,
         translate: this.translate,
         width: this.width,
+        useWindowAsScrollContainer,
       });
     };
 


### PR DESCRIPTION
fix: https://github.com/clauderic/react-sortable-hoc/issues/758

resolve mobile devices using useWindowAsScrollContainer cannot scroll 