### PR TITLE
HOC should extends PureComponent 

### DIFF
--- a/src/SortableElement/index.js
+++ b/src/SortableElement/index.js
@@ -18,7 +18,7 @@ export default function sortableElement(
   WrappedComponent,
   config = {withRef: false},
 ) {
-  return class WithSortableElement extends React.Component {
+  return class WithSortableElement extends React.PureComponent {
     static displayName = provideDisplayName(
       'sortableElement',
       WrappedComponent,


### PR DESCRIPTION
We faced a performance issue recently while using react-sortable-hoc.
If we have a large list, such as 300 to 400, and whenever its parent re-renders all the child also re renders.

So raising the PR to change it to PureComponent to get the performance benefit.
Though I am a bit worried about folks who are already using it and have not taken care of the cons of using PureComponent.

