### PR TITLE
identify element as scrollable when using non standard webkit css

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -241,7 +241,7 @@ export function getLockPixelOffsets({height, width, lockOffset}) {
 
 function isScrollable(el) {
   const computedStyle = window.getComputedStyle(el);
-  const overflowRegex = /(auto|scroll)/;
+  const overflowRegex = /(auto|overlay|scroll)/;
   const properties = ['overflow', 'overflowX', 'overflowY'];
 
   return properties.find((property) =>


### PR DESCRIPTION
Support 'overlay' to identify whether an element is 'scrollable' too