### PR TITLE
Fix bug with window scroll container

### DIFF
--- a/src/.stories/Storybook.scss
+++ b/src/.stories/Storybook.scss
@@ -11,6 +11,10 @@ $focusedOutlineColor: #4c9ffe;
   align-items: center;
 }
 
+.rootAutoHeight {
+  height: auto;
+}
+
 // Base styles
 .list {
   width: 400px;
@@ -120,6 +124,10 @@ $focusedOutlineColor: #4c9ffe;
   white-space: nowrap;
   border: 0;
   background-color: transparent;
+}
+
+.gridAutoHeight {
+  height: auto;
 }
 
 .gridItem {

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -597,6 +597,26 @@ storiesOf('General | Layout / Grid', module)
         />
       </div>
     );
+  })
+  .add('Window as scroll container', () => {
+    return (
+      <div className={classNames(style.root, style.rootAutoHeight)}>
+        <ListWrapper
+          component={SortableList}
+          axis={'xy'}
+          items={getItems(40, false)}
+          helperClass={style.stylizedHelper}
+          useWindowAsScrollContainer
+          className={classNames(
+            style.list,
+            style.stylizedList,
+            style.grid,
+            style.gridAutoHeight,
+          )}
+          itemClass={classNames(style.stylizedItem, style.gridItem)}
+        />
+      </div>
+    );
   });
 
 storiesOf('General | Configuration / Options', module)

--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -438,22 +438,20 @@ const ShrinkingSortableList = SortableContainer(
   },
 );
 
-const NestedSortableList = SortableContainer(
-  ({className, items, isSorting}) => {
-    return (
-      <div className={className}>
-        {items.map((value, index) => (
-          <Category
-            tabbable
-            key={`category-${value}`}
-            index={index}
-            value={value}
-          />
-        ))}
-      </div>
-    );
-  },
-);
+const NestedSortableList = SortableContainer(({className, items}) => {
+  return (
+    <div className={className}>
+      {items.map((value, index) => (
+        <Category
+          tabbable
+          key={`category-${value}`}
+          index={index}
+          value={value}
+        />
+      ))}
+    </div>
+  );
+});
 
 storiesOf('General | Layout / Vertical list', module)
   .add('Basic setup', () => {
@@ -515,11 +513,6 @@ storiesOf('General | Layout / Horizontal list', module).add(
 
 storiesOf('General | Layout / Grid', module)
   .add('Basic setup', () => {
-    const transformOrigin = {
-      x: 0,
-      y: 0,
-    };
-
     return (
       <div className={style.root}>
         <ListWrapper

--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -260,6 +260,12 @@ export default function sortableContainer(
         const margin = getElementMargin(node);
         const gridGap = getContainerGridGap(this.container);
         const containerBoundingRect = this.scrollContainer.getBoundingClientRect();
+
+        // Need for correct sorting behavior in grid layout with enabled `useWindowAsScrollContainer`
+        if (useWindowAsScrollContainer) {
+          containerBoundingRect.width = this.container.clientWidth;
+        }
+
         const dimensions = getHelperDimensions({index, node, collection});
 
         this.node = node;
@@ -645,9 +651,9 @@ export default function sortableContainer(
 
         // For keyboard sorting, we want user input to dictate the position of the nodes
         const mustShiftBackward =
-          isKeySorting && (index > this.index && index <= prevIndex);
+          isKeySorting && index > this.index && index <= prevIndex;
         const mustShiftForward =
-          isKeySorting && (index < this.index && index >= prevIndex);
+          isKeySorting && index < this.index && index >= prevIndex;
 
         const translate = {
           x: 0,


### PR DESCRIPTION
### Problem

There were some issues about incorrect sorting behavior in grid list with enabled ``useWindowAsScrollContainer``, for example, https://github.com/clauderic/react-sortable-hoc/issues/577.

When prop ``useWindowAsScrollContainer`` is set to ``true``, sorting in grid list does not work properly:

https://user-images.githubusercontent.com/37641303/125896642-c22e9532-d075-449c-bccc-ce96d08ce47c.mp4

### Solution

Such behavior is caused because of using root ``html`` element as scrolling container. Scrolling container's width is used for counting of new coordinates of list item during sorting. ``html`` element has width much more, than grid list container element, new coordinates counts wrong, that's why we can see incorrect sorting behavior.

This PR fixes issue with incorrect sorting by using width of grid container instead of using width of ``html`` element, where it's needed.

The result of this fix:

https://user-images.githubusercontent.com/37641303/125897590-8ffa7933-2b37-4bc8-a714-4dae347fbae8.mp4

 
