### PR TITLE
fix: Fix dragging on iOS when zooming

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -164,9 +164,12 @@ export default function sortableContainer(
         if (!distance) {
           if (this.props.pressDelay === 0) {
             this.handlePress(event);
-          } else {
+          } else if (!this.pressTimer) {
             this.pressTimer = setTimeout(
-              () => this.handlePress(event),
+              () => {
+                this.pressTimer = 0;
+                this.handlePress(event);
+              },
               this.props.pressDelay,
             );
           }
@@ -220,6 +223,7 @@ export default function sortableContainer(
       if (!sorting) {
         if (!distance) {
           clearTimeout(this.pressTimer);
+          this.pressTimer = 0;
         }
         this.manager.active = null;
       }


### PR DESCRIPTION
This commit is fixing a bug when user of iOS zooming screen with sortable elements. When two sortable items are touched then ```handlePress``` function fires two times and after releasing item one of them runs away from screen.

https://user-images.githubusercontent.com/42856876/156889617-dbb30691-3ce9-4ae3-826a-cb9d6851b3bb.mp4


