### PR TITLE
Allow installation with react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.7",
-    "react": "^16.3.0 || ^17.0.0",
+    "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.3.0 || ^17.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There seems not lot of changes in react 18: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html so I think this should be possible without any efforts. 