### PR TITLE
fix: disabling start for middle mouse button

### DIFF
--- a/src/SortableContainer/index.js
+++ b/src/SortableContainer/index.js
@@ -36,6 +36,8 @@ import {
   defaultKeyCodes,
 } from './props';
 
+const LEFT_MOUSE_BUTTON = 0;
+
 export const SortableContext = React.createContext({
   manager: {},
 });
@@ -124,7 +126,7 @@ export default function sortableContainer(
     handleStart = (event) => {
       const {distance, shouldCancelStart} = this.props;
 
-      if (event.button === 2 || shouldCancelStart(event)) {
+      if (event.button !== LEFT_MOUSE_BUTTON || shouldCancelStart(event)) {
         return;
       }
 


### PR DESCRIPTION
Fix: disabling start for middle mouse button

There are 5 possible values for `event.button`:

> 0: Main button pressed, usually the left button or the un-initialized state
> 1: Auxiliary button pressed, usually the wheel button or the middle button (if present)
> 2: Secondary button pressed, usually the right button
> 3: Fourth button, typically the Browser Back button
> 4: Fifth button, typically the Browser Forward button

(Source: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button)

We should not start dragging if either middle or right mouse buttons are clicked

I did not see any unit tests, please let me know if I missed that, as I would be happy to add a unit test.