### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Alternatively, an UMD build is also available:
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
-import { arrayMoveImmutable } from 'array-move';
+import {arrayMoveImmutable} from 'array-move';
 
 const SortableItem = SortableElement(({value}) => <li>{value}</li>);
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Alternatively, an UMD build is also available:
 import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
-import arrayMove from 'array-move';
+import { arrayMoveImmutable } from 'array-move';
 
 const SortableItem = SortableElement(({value}) => <li>{value}</li>);
 
@@ -81,7 +81,7 @@ class SortableComponent extends Component {
   };
   onSortEnd = ({oldIndex, newIndex}) => {
     this.setState(({items}) => ({
-      items: arrayMove(items, oldIndex, newIndex),
+      items: arrayMoveImmutable(items, oldIndex, newIndex),
     }));
   };
   render() {


### PR DESCRIPTION
`array-move` lib changed to not use `export default`, "Basic Example" for devs in "copy-paste mode" wont be able to make this lib work, this will give directions for devs to the exact code they need in order to test a basic example