### PR TITLE
fix: change deprecated React.SFC to React.FC

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,7 +105,7 @@ export type WrappedComponentFactory<P> = (props: P) => JSX.Element;
 
 export type WrappedComponent<P> =
   | React.ComponentClass<P>
-  | React.SFC<P>
+  | React.FC<P>
   | WrappedComponentFactory<P>;
 
 export function SortableContainer<P>(


### PR DESCRIPTION
`React.SFC` was deprecated from React 16 version, and React 18 version was completely removed. 
Therefore, Compile error are occurring in React 18 and typescript environment.

So, I change to `React.FC` which is proposed way in [the official document](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a51e3613b44c4ae400d040592bb4f56fd3fa8a4f/types/react/index.d.ts#L528-L534)

related issue : https://github.com/clauderic/react-sortable-hoc/issues/855