### PR TITLE
Update types in types/index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,7 +105,7 @@ export type WrappedComponentFactory<P> = (props: P) => JSX.Element;
 
 export type WrappedComponent<P> =
   | React.ComponentClass<P>
-  | React.SFC<P>
+  | React.FunctionComponent<P>
   | WrappedComponentFactory<P>;
 
 export function SortableContainer<P>(


### PR DESCRIPTION
# Description

The current types trigger an error:
```
node_modules/react-sortable-hoc/types/index.d.ts:108:11 - error TS2694: Namespace 'React' has no exported member 'SFC'.

108   | React.SFC<P>
              ~~~
```

Indeed, `React.StatelessComponent` has been removed from the react types (see https://stackoverflow.com/questions/44375759/how-should-i-declare-a-stateless-functional-component-with-typescript-in-react)

This PR fixes this error.